### PR TITLE
[FE] #18: 페이지가 최대 회면을 넘어갔을 때 배경은 늘어나지 않는 버그 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,9 +3,9 @@ import Header from '@/components/Header';
 
 function App() {
   return (
-    <div className="bg-background-100">
+    <div className="flex bg-background-100">
       <Header />
-      <main className="container mx-auto pt-28 min-h-screen">
+      <main className="container mx-auto pt-28 min-h-screen grow">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## 리뷰 포인트

페이지가 최대 회면을 넘어갔을 때 배경은 늘어나지 않는 버그 수정

`min-height: 100vh;` 의 경우 hight이 설정되지 않은 것으로 간주되어 내부에서 height:100% 가 적용되지 않아요...
따라서 flex와 grow를 추가로 사용해 페이지에서 `h-full`이 적용되고 페이지가 `height: screen`을 넘어가도 `App`이 늘어나도록 수정했어요!