### PR TITLE
[BE] #23: 백엔드 서버 배포 파이프라인 구축

### DIFF
--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -1,0 +1,74 @@
+name: Build & Deploy Spring Boot Application
+
+on:
+  push:
+    branches: [ "feat#23" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Move to server directory
+        run: cd server
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_REPO }}:latest
+
+  # deploy:
+  #   needs: build
+
+  #   runs-on: ubuntu-20.04
+
+  #   steps:
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: ap-northeast-2
+
+  #     - name: Deploy
+  #       uses: appleboy/ssh-action@v0.1.6
+  #       with:
+  #         host: ${{ secrets.EC2_HOST }}
+  #         port: 22
+  #         username: ${{ secrets.EC2_USERNAME }}
+  #         key: ${{ secrets.EC2_PRIVATE_KEY }}
+  #         script: |
+  #           docker stop $(docker ps -a -q)
+  #           docker rm $(docker ps -a -q -f status=exited)
+  #           docker rm $(docker ps -a -q -f status=created)
+  #           docker rmi $(docker images -q)
+  #           docker pull ${{ secrets.DOCKER_REPO }}
+  #           docker run -d -p 443:80 -p 80:80 -v /home/${{ secrets.EC2_USERNAME }}/data:/data ${{ secrets.DOCKER_REPO }} --name tayoServer

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -22,6 +22,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Create application-secret.yml
+        run: |
+          touch ./server/src/main/resources/application-secret.yml 
+          echo "${{ secrets.APPLICATION_SECRET }}" > ./src/main/resources/application-secret.yml
+
       - name: Build with Gradle
         run: |
           cd ./server

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -45,3 +45,31 @@ jobs:
           file: ./server/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
+  
+  deploy:
+    needs: build
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Deploy
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          port: 22
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            docker stop $(docker ps -a -q)
+            docker rm $(docker ps -a -q -f status=exited)
+            docker rm $(docker ps -a -q -f status=created)
+            docker rmi $(docker images -q)
+            docker pull ${{ secrets.DOCKER_REPO }}
+            docker run -d -p 443:80 -p 80:80 -v /home/${{ secrets.EC2_USERNAME }}/data:/data ${{ secrets.DOCKER_REPO }} --name tayoServer

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -44,31 +44,3 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_REPO }}:latest
-
-  # deploy:
-  #   needs: build
-
-  #   runs-on: ubuntu-20.04
-
-  #   steps:
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: ap-northeast-2
-
-  #     - name: Deploy
-  #       uses: appleboy/ssh-action@v0.1.6
-  #       with:
-  #         host: ${{ secrets.EC2_HOST }}
-  #         port: 22
-  #         username: ${{ secrets.EC2_USERNAME }}
-  #         key: ${{ secrets.EC2_PRIVATE_KEY }}
-  #         script: |
-  #           docker stop $(docker ps -a -q)
-  #           docker rm $(docker ps -a -q -f status=exited)
-  #           docker rm $(docker ps -a -q -f status=created)
-  #           docker rmi $(docker images -q)
-  #           docker pull ${{ secrets.DOCKER_REPO }}
-  #           docker run -d -p 443:80 -p 80:80 -v /home/${{ secrets.EC2_USERNAME }}/data:/data ${{ secrets.DOCKER_REPO }} --name tayoServer

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -44,4 +44,4 @@ jobs:
           context: ./server
           file: ./server/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_REPO }}:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -2,7 +2,7 @@ name: Build & Deploy Spring Boot Application
 
 on:
   push:
-    branches: [ "feat#23" ]
+    branches: [ "feat/#23" ]
 
 permissions:
   contents: read

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Move to server directory
-        run: cd server
-
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -52,12 +49,20 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Get Github Actions IP
+        id: ip
+        uses: haythem/public-ip@v1.2
+        
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
+          
+      - name: Add Github Actions IP to Security group
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id ${{ secrets.AWS_EC2_SG }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
 
       - name: Deploy
         uses: appleboy/ssh-action@v0.1.6
@@ -73,3 +78,7 @@ jobs:
             docker rmi $(docker images -q)
             docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
             docker run -d -p 443:80 -p 80:80 -p 8080:8080 -v /home/${{ secrets.EC2_USERNAME }}/data:/data --name tayoServer ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+
+      - name: Remove Github Actions IP From Security Group
+        run: |
+          aws ec2 revoke-security-group-ingress --group-id ${{ secrets.AWS_EC2_SG }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -71,5 +71,5 @@ jobs:
             docker rm $(docker ps -a -q -f status=exited)
             docker rm $(docker ps -a -q -f status=created)
             docker rmi $(docker images -q)
-            docker pull ${{ secrets.DOCKER_REPO }}
-            docker run -d -p 443:80 -p 80:80 -v /home/${{ secrets.EC2_USERNAME }}/data:/data ${{ secrets.DOCKER_REPO }} --name tayoServer
+            docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+            docker run -d -p 443:80 -p 80:80 -v /home/${{ secrets.EC2_USERNAME }}/data:/data ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} --name tayoServer

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
+          cd ./server
           chmod +x ./gradlew
           ./gradlew clean build -x test
 
@@ -40,7 +41,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: .
-          file: ./Dockerfile
+          context: ./server
+          file: ./server/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_REPO }}:latest

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -2,7 +2,7 @@ name: Build & Deploy Spring Boot Application
 
 on:
   push:
-    branches: [ "feat/#23" ]
+    branches: [ "deploy" ]
 
 permissions:
   contents: read

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create application-secret.yml
         run: |
           touch ./server/src/main/resources/application-secret.yml 
-          echo "${{ secrets.APPLICATION_SECRET }}" > ./src/main/resources/application-secret.yml
+          echo "${{ secrets.APPLICATION_SECRET }}" > ./server/src/main/resources/application-secret.yml
 
       - name: Build with Gradle
         run: |

--- a/.github/workflows/be-gradle.yml
+++ b/.github/workflows/be-gradle.yml
@@ -72,4 +72,4 @@ jobs:
             docker rm $(docker ps -a -q -f status=created)
             docker rmi $(docker images -q)
             docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
-            docker run -d -p 443:80 -p 80:80 -v /home/${{ secrets.EC2_USERNAME }}/data:/data ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} --name tayoServer
+            docker run -d -p 443:80 -p 80:80 -p 8080:8080 -v /home/${{ secrets.EC2_USERNAME }}/data:/data --name tayoServer ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:17
+
+ARG JAR_FILE=./build/libs/tayo-0.0.1-SNAPSHOT.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
close #23 

## DONE

- [x] 백엔드 서버 배포 파이프라인 구축
- [x] DB 설정 파일 Github Secret으로 관리

## 리뷰 포인트

- `DockerFile`: 도커 이미지 빌드를 위한 설정 파일입니다. JDK 17 환경에서 .jar 실행파일을 실행하는 명령어를 담고 있습니다.
- `be-gradle.yml`: 깃허브 액션 워크플로우 정의 파일입니다. 
  - `deploy` 브랜치에 `push` 이벤트가 발생하면 자동으로 트리거되도록 설정
  - 깃허브 액션 빌드 서버에서 스프링부트 웹서버를 빌드하고 Docker Hub에 push
  - EC2에 ssh 를 이용해서 접속하여 Docker Hub의 이미지를 pull 받아 실행

## 스크린 샷
### 배포 파이프라인 Arcitecture
![Untitled (7)](https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/70956926/96ab8f3c-0243-4e64-9869-6d4d2452fe2d)
