### PR TITLE
[BE] #45: 파일 업로드 크기 20BM로 제한

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.config.import=optional:classpath:application-secret.yml
+spring.servlet.multipart.max-file-size=20MB
+spring.servlet.multipart.max-request-size=20MB


### PR DESCRIPTION
## TODO

- [x] 차량 이미지 업로드 시 용량 초과 오류 해결하기

## 리뷰 포인트

- 기존 고화질 사진을 업로드 할 때 아래와 같은 오류가 떠서 알아보니 스프링 애플리케이션에서는 기본적으로 파일 업로드 크기를 제한하고 있어서 업로드 가능한 최대 크기를 20MB로 수정하였습니다. 20MB로 잡은 이유는 핸드폰으로 사진을 찍었을 때의 사진 하나의 사이즈가 3MB 정도여서 5장의 사진을 업로드 할 경우 넉넉하게 20MB가 필요할 것이라 판단하였습니다.
```json
{
    "success": false,
    "code": 500,
    "message": "Maximum upload size exceeded"
}
```

close #45 