### PR TITLE
[BE] #64: MethodArgumentNotValidException 예외처리 추가

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/common/ResponseDto.java
+++ b/server/src/main/java/com/hexacore/tayo/common/ResponseDto.java
@@ -22,4 +22,8 @@ public class ResponseDto {
     public static ResponseDto error(ErrorCode errorCode, Exception e) {
         return new ResponseDto(false, errorCode.getCode(), errorCode.getErrorMessage(e));
     }
+
+    public static ResponseDto error(ErrorCode errorCode, String message) {
+        return new ResponseDto(false, errorCode.getCode(), errorCode.getErrorMessage(message));
+    }
 }

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -32,6 +32,8 @@ public enum ErrorCode {
 
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드에 실패했습니다."),
 
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 문제 발생, 다음에 시도해주세요.");
     public final HttpStatus httpStatus;
     public final String errorMessage;

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorExceptionHandler.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorExceptionHandler.java
@@ -3,6 +3,8 @@ package com.hexacore.tayo.common.errors;
 import com.hexacore.tayo.common.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,6 +15,14 @@ public class ErrorExceptionHandler {
     public ResponseEntity<ResponseDto> handleException(Exception e) {
         return new ResponseEntity<>(ResponseDto.error(ErrorCode.SERVER_ERROR, e),
                 HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto> handleValidationExceptions(MethodArgumentNotValidException e) {
+        BindingResult result = e.getBindingResult();
+        String message = result.getFieldErrors().get(0).getDefaultMessage();
+        return new ResponseEntity<>(ResponseDto.error(ErrorCode.VALIDATION_ERROR, message),
+                HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(GeneralException.class)


### PR DESCRIPTION
## DONE

- [x] MethodArgumentNotValidException에 대한 ExceptionHandler 추가

## 리뷰 포인트

- getBindingResult 메서드를 통해 데이터 바인딩 및 유효성 검사를 수행한 결과를 담고 있는 객체를 받아와 해당 결과에서 에러메시지를 추출하여 ResponseDto의 메시지 값으로 반환되도록 구현하였습니다.

### 사용 예시
예를 들어 유저 로그인 시 이메일 형식이 맞는지 확인하는 과정을 `@Valid` 를 통해 검증한다고 가정하면, (컨트롤러에서 검증할 dto 앞에 붙여주면 됩니다.)
```java
public class LoginDto {
    @NotBlank(message = "이메일은 필수 입력 값입니다.")
    @Email(message = "이메일 형식에 맞지 않습니다.")
    private String email;
    // 다른 필드값
}
```
다음과 같이 로그인 dto에서 지정한 유효성 검증 메시지에 대해 올바르지 않은 입력값을 보냈을 때 사전에 지정한 ResponseDto의 message가 유효성 검증 메시지 값으로 설정되어 반환됩니다.
<img width="441" alt="스크린샷 2024-02-11 오후 11 26 00" src="https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/90602694/d42edcc6-cd21-4d62-af30-30eb29c1fdfe">

close #64 