### PR TITLE
[BE] #61: 차량 등록, 삭제, 세부 모델 조회 API - 테스트 코드 작성

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.hibernate:hibernate-spatial:6.4.3.Final'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/server/src/main/java/com/hexacore/tayo/car/CarController.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarController.java
@@ -4,6 +4,7 @@ import com.hexacore.tayo.car.model.CarUpdateDto;
 import com.hexacore.tayo.car.model.DateListDto;
 import com.hexacore.tayo.car.model.PostCarDto;
 import com.hexacore.tayo.common.ResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -31,8 +32,9 @@ public class CarController {
     }
 
     @PostMapping()
-    public ResponseEntity<ResponseDto> createCar(@ModelAttribute PostCarDto postCarDto) {
-        ResponseDto responseDto = carService.createCar(postCarDto);
+    public ResponseEntity<ResponseDto> createCar(@Valid @ModelAttribute PostCarDto postCarDto) {
+        // TODO: JWT 토큰에서 userId 가져와서 로그인한 경우에만 실행되도록
+        ResponseDto responseDto = carService.createCar(postCarDto, null);
         return new ResponseEntity<>(responseDto, HttpStatusCode.valueOf(responseDto.getCode()));
     }
 

--- a/server/src/main/java/com/hexacore/tayo/car/CarRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarRepository.java
@@ -13,6 +13,5 @@ public interface CarRepository extends JpaRepository<CarEntity, Long> {
 
     List<CarEntity> findByOwner_IdAndIsDeletedFalse(Long ownerId);
 
-
     List<CarEntity> findByCarNumberAndIsDeletedFalse(String carNumber);
 }

--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -49,17 +49,19 @@ public class CarService {
 
     /* 차량 등록 */
     @Transactional
-    public ResponseDto createCar(PostCarDto postCarDto) {
+    public ResponseDto createCar(PostCarDto postCarDto, Long userId) {
         // TODO: JWT 토큰에서 userId 가져와서 로그인한 경우에만 실행되도록
-        Long userId = 1L;
-
-        if (checkUserHasCar(userId)) {
+        if (checkUserHasCar(userId != null ? userId : 1L)) {
             // 유저가 이미 차량을 등록한 경우
             throw new GeneralException(ErrorCode.USER_ALREADY_HAS_CAR);
         }
         if (checkDuplicateCarNumber(postCarDto.getCarNumber())) {
             // 중복되는 차량 번호가 있을 경우
             throw new GeneralException(ErrorCode.CAR_NUMBER_DUPLICATED);
+        }
+        if (!isIndexSizeEqualsToImageSize(postCarDto.getImageIndexes(), postCarDto.getImageFiles())) {
+            // index 리스트 길이와 image 리스트 길이가 같지 않은 경우
+            throw new GeneralException(ErrorCode.IMAGE_INDEX_MISMATCH);
         }
 
         // 등록에 필요한 정보 가져오기
@@ -68,7 +70,8 @@ public class CarService {
                 .orElseThrow(() -> new GeneralException(ErrorCode.CAR_MODEL_NOT_FOUND));
         Point position = createPoint(postCarDto.getPosition());
 
-        CarEntity car = carRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(userId, postCarDto.getCarNumber())
+        CarEntity car = carRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(userId != null ? userId : 1L,
+                        postCarDto.getCarNumber())
                 .orElse(null);
 
         if (car != null) {
@@ -89,7 +92,7 @@ public class CarService {
         } else {
             // 유저가 이전에 등록한 같은 번호의 차가 없는 경우 CREATE
             CarEntity carEntity = CarEntity.builder()
-                    .owner(UserEntity.builder().id(userId).build())
+                    .owner(UserEntity.builder().id(userId != null ? userId : 1L).build())
                     .model(model)
                     .carNumber(postCarDto.getCarNumber())
                     .mileage(postCarDto.getMileage())
@@ -151,7 +154,7 @@ public class CarService {
             imageRepository.save(image);
         });
 
-        return ResponseDto.success(HttpStatus.OK);
+        return ResponseDto.success(HttpStatus.NO_CONTENT);
     }
 
     /* 에약 가능 날짜 조회 */
@@ -229,6 +232,10 @@ public class CarService {
 
     /* 이미지 파일을 S3에 업로드하고 URL 반환 */
     private String uploadImage(MultipartFile image) {
+        if (image.getContentType() == null || !image.getContentType().startsWith("image/")) {
+            // Content-Type이 이미지 파일이 아닌 경우
+            throw new GeneralException(ErrorCode.INVALID_IMAGE_TYPE);
+        }
         String originalFilename = image.getOriginalFilename();
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(image.getSize());
@@ -252,5 +259,9 @@ public class CarService {
     /* 중복된 차량 번호가 있는지 체크 */
     private Boolean checkDuplicateCarNumber(String carNumber) {
         return !carRepository.findByCarNumberAndIsDeletedFalse(carNumber).isEmpty();
+    }
+
+    private Boolean isIndexSizeEqualsToImageSize(List<Integer> imageIndexes, List<MultipartFile> imageFiles) {
+        return imageIndexes.size() == imageFiles.size();
     }
 }

--- a/server/src/main/java/com/hexacore/tayo/car/model/ModelEntity.java
+++ b/server/src/main/java/com/hexacore/tayo/car/model/ModelEntity.java
@@ -27,6 +27,6 @@ public class ModelEntity extends BaseTime {
     @Column(name = "category", nullable = false)
     private String category;
 
-    @Column(name = "sub_category")
+    @Column(name = "sub_category", unique = true)
     private String subCategory;
 }

--- a/server/src/main/java/com/hexacore/tayo/car/model/ModelEntity.java
+++ b/server/src/main/java/com/hexacore/tayo/car/model/ModelEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,6 +16,7 @@ import lombok.Setter;
 @Entity
 @Setter
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "Model")

--- a/server/src/main/java/com/hexacore/tayo/car/model/PostCarDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/model/PostCarDto.java
@@ -1,27 +1,39 @@
 package com.hexacore.tayo.car.model;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor
 public class PostCarDto {
 
+    @NotNull
     private String carNumber;
+    @NotNull
     private String carName;
+    @NotNull
     private Double mileage;
+    @NotNull
     private String fuel;
+    @NotNull
     private String type;
+    @NotNull
     private Integer capacity;
+    @NotNull
     private Integer year;
+    @NotNull
     private Integer feePerHour;
+    @NotNull
     private String address;
+    @NotNull
     private PositionDto position;
     private String description;
+    @NotNull
     private List<MultipartFile> imageFiles;
+    @NotNull
     private List<Integer> imageIndexes;
 
 }

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -29,8 +29,10 @@ public enum ErrorCode {
     CAR_MODEL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 모델명입니다."),
     CAR_NUMBER_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 차량 번호입니다."),
     USER_ALREADY_HAS_CAR(HttpStatus.BAD_REQUEST, "유저가 이미 차량을 등록했습니다."),
+    IMAGE_INDEX_MISMATCH(HttpStatus.BAD_REQUEST, "이미지 개수와 인덱스 개수가 일치하지 않습니다."),
 
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드에 실패했습니다."),
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 타입입니다."),
 
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 문제 발생, 다음에 시도해주세요.");
     public final HttpStatus httpStatus;

--- a/server/src/main/java/com/hexacore/tayo/user/UserRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/user/UserRepository.java
@@ -1,0 +1,8 @@
+package com.hexacore.tayo.user;
+
+import com.hexacore.tayo.user.model.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+}

--- a/server/src/test/java/com/hexacore/tayo/car/CarControllerTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarControllerTest.java
@@ -1,0 +1,99 @@
+package com.hexacore.tayo.car;
+
+import com.hexacore.tayo.car.model.CategoryDto;
+import com.hexacore.tayo.car.model.CategoryListDto;
+import com.hexacore.tayo.car.model.PostCarDto;
+import com.hexacore.tayo.common.DataResponseDto;
+import com.hexacore.tayo.common.ResponseDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CarControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CarService carService;
+
+    @Test
+    @DisplayName("GET /cars/categories 컨트롤러 테스트")
+    void getCategoriesTest() throws Exception {
+        // given
+        BDDMockito.given(carService.getCategories())
+                .willReturn(DataResponseDto.of(new CategoryListDto(List.of(new CategoryDto("모델명", "모델명 서브모델명")))));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/cars/categories")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.models").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.models[0].category").value("모델명"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.models[0].subCategory").value("모델명 서브모델명"));
+    }
+
+    @Test
+    @DisplayName("POST /cars 컨트롤러 테스트")
+    void createCarTest() throws Exception {
+        // given
+        MockMultipartFile image1 = new MockMultipartFile("imageFiles", "filename1.png", "image/png",
+                "<<png data>>".getBytes());
+
+        BDDMockito.given(carService.createCar(Mockito.any(PostCarDto.class), Mockito.any()))
+                .willReturn(ResponseDto.success(HttpStatus.CREATED));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/cars")
+                        .file(image1)
+                        .param("carNumber", "11주 1111")
+                        .param("carName", "모델명 서브모델명")
+                        .param("mileage", "10.0")
+                        .param("fuel", "가솔린")
+                        .param("type", "경차")
+                        .param("capacity", "2")
+                        .param("year", "2020")
+                        .param("feePerHour", "10000")
+                        .param("address", "경기도 테스트 주소")
+                        .param("position.lat", "37.5665")
+                        .param("position.lng", "126.9780")
+                        .param("description", "설명")
+                        .param("imageIndexes", "1", "2", "3", "4", "5").contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(MockMvcResultMatchers.status().isCreated());
+    }
+
+    @Test
+    @DisplayName("POST /cars 컨트롤러 테스트: 필수 인자가 모두 전달되지 않은 경우")
+    void createCarFailTest() {
+        // TODO: MethodArgumentNotValidException 예외처리 PR 머지된 후 구현
+
+    }
+
+    @Test
+    @DisplayName("DELETE /cars/:carId 컨트롤러 테스트")
+    void deleteCarTest() throws Exception {
+        // given
+        Long carId = 1L;
+        BDDMockito.given(carService.deleteCar(carId))
+                .willReturn(ResponseDto.success(HttpStatus.NO_CONTENT));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/cars/{carId}", carId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+}

--- a/server/src/test/java/com/hexacore/tayo/car/CarRepositoryTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.hexacore.tayo.car;
+
+import com.hexacore.tayo.car.model.CarEntity;
+import com.hexacore.tayo.car.model.CarType;
+import com.hexacore.tayo.car.model.ModelEntity;
+import com.hexacore.tayo.user.UserRepository;
+import com.hexacore.tayo.user.model.UserEntity;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class CarRepositoryTest {
+
+    @Autowired
+    private CarRepository carRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ModelRepository modelRepository;
+
+    private UserEntity user;
+    private ModelEntity model;
+
+    @BeforeEach
+    void createUserAndModel() {
+        UserEntity user = userRepository.save(
+                UserEntity.builder().email("test@test.com").name("테스트").nickname("테스트 유저").phoneNumber("010-0000-0000")
+                        .password("1234")
+                        .build());
+        ModelEntity model = modelRepository.save(
+                ModelEntity.builder().category("모델명").subCategory("모델명 세부모델명").build());
+        this.user = user;
+        this.model = model;
+    }
+
+    @Test
+    @DisplayName("ownerId와 carNumber로 검색해서 isDelete = true인 CarEntity를 반환한다")
+    void findByOwner_IdAndCarNumberAndIsDeletedTrue() {
+        // given
+        String carNumber = "11주 1111";
+        carRepository.save(
+                CarEntity.builder().owner(user).model(model).carNumber(carNumber).type(CarType.LIGHT).capacity(2)
+                        .address("경기도 테스트 주소")
+                        .feePerHour(1000).position(new GeometryFactory().createPoint(new Coordinate(10.0, 10.0)))
+                        .isDeleted(true).build());
+
+        // when
+        Optional<CarEntity> car = carRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(user.getId(), carNumber);
+
+        // then
+        Assertions.assertThat(car.isPresent()).isTrue();
+        Assertions.assertThat(car.get().getOwner().getId()).isEqualTo(user.getId());
+        Assertions.assertThat(car.get().getCarNumber()).isEqualTo(carNumber);
+        Assertions.assertThat(car.get().getIsDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("ownerId로 검색해서 isDelete = false인 CarEntity 리스트를 반환한다")
+    void findByOwner_IdAndIsDeletedFalse() {
+        // given
+        carRepository.save(
+                CarEntity.builder().owner(user).model(model).carNumber("11주 1111").type(CarType.LIGHT).capacity(2)
+                        .address("경기도 테스트 주소")
+                        .feePerHour(1000).position(new GeometryFactory().createPoint(new Coordinate(10.0, 10.0)))
+                        .isDeleted(false).build());
+
+        // when
+        List<CarEntity> cars = carRepository.findByOwner_IdAndIsDeletedFalse(user.getId());
+
+        // then
+        Assertions.assertThat(cars.size()).isEqualTo(1);
+        Assertions.assertThat(cars.get(0).getOwner().getId()).isEqualTo(user.getId());
+        Assertions.assertThat(cars.get(0).getIsDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("carNumber로 검색해서 isDeleted = false인 CarEntity 리스트를 반환한다")
+    void findByCarNumberAndIsDeletedFalse() {
+        // given
+        String carNumber = "11주 1111";
+        carRepository.save(
+                CarEntity.builder().owner(user).model(model).carNumber(carNumber).type(CarType.LIGHT).capacity(2)
+                        .address("경기도 테스트 주소")
+                        .feePerHour(1000).position(new GeometryFactory().createPoint(new Coordinate(10.0, 10.0)))
+                        .isDeleted(false).build());
+
+        // when
+        List<CarEntity> cars = carRepository.findByCarNumberAndIsDeletedFalse(carNumber);
+
+        // then
+        Assertions.assertThat(cars.size()).isEqualTo(1);
+        Assertions.assertThat(cars.get(0).getCarNumber()).isEqualTo(carNumber);
+        Assertions.assertThat(cars.get(0).getIsDeleted()).isFalse();
+    }
+}

--- a/server/src/test/java/com/hexacore/tayo/car/CarRepositoryTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarRepositoryTest.java
@@ -58,7 +58,7 @@ public class CarRepositoryTest {
         Optional<CarEntity> car = carRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(user.getId(), carNumber);
 
         // then
-        Assertions.assertThat(car.isPresent()).isTrue();
+        Assertions.assertThat(car).isPresent();
         Assertions.assertThat(car.get().getOwner().getId()).isEqualTo(user.getId());
         Assertions.assertThat(car.get().getCarNumber()).isEqualTo(carNumber);
         Assertions.assertThat(car.get().getIsDeleted()).isTrue();

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceCreateCarTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceCreateCarTest.java
@@ -1,0 +1,233 @@
+package com.hexacore.tayo.car;
+
+import static org.mockito.BDDMockito.given;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.hexacore.tayo.car.model.CarEntity;
+import com.hexacore.tayo.car.model.ModelEntity;
+import com.hexacore.tayo.car.model.PositionDto;
+import com.hexacore.tayo.car.model.PostCarDto;
+import com.hexacore.tayo.common.ResponseDto;
+import com.hexacore.tayo.common.errors.ErrorCode;
+import com.hexacore.tayo.common.errors.GeneralException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class CarServiceCreateCarTest {
+
+    @Mock
+    private AmazonS3 amazonS3Client;
+    @Mock
+    private ImageRepository imageRepository;
+    @Mock
+    private CarRepository mockCarRepository;
+    @Mock
+    private ModelRepository mockModelRepository;
+    @InjectMocks
+    private CarService carService;
+
+
+    @Test
+    @DisplayName("새로운 차량을 등록하는 경우 CarRepository.save() 메소드가 호출된다")
+    void createCar_create() throws MalformedURLException {
+        // given
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image2", "filename2.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image3", "filename3.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image4", "filename4.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image5", "filename5.png", "image/png", "dummy".getBytes())),
+                List.of(1, 2, 3, 4, 5));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Collections.emptyList());
+        given(mockCarRepository.findByCarNumberAndIsDeletedFalse(postCarDto.getCarNumber()))
+                .willReturn(Collections.emptyList());
+        given(mockModelRepository.findBySubCategory(postCarDto.getCarName()))
+                .willReturn(Optional.of(ModelEntity.builder().category("모델명").subCategory("모델명 서브모델명").build()));
+        given(mockCarRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(0L, postCarDto.getCarNumber()))
+                .willReturn(Optional.empty());
+        given(amazonS3Client.getUrl(Mockito.any(), Mockito.any())).willReturn(new URL("http://mockUrl"));
+
+        // when
+        ResponseDto response = carService.createCar(postCarDto, 0L);
+
+        // then
+        BDDMockito.verify(mockCarRepository, Mockito.times(1)).save(Mockito.any(CarEntity.class));
+        Assertions.assertThat(response.getSuccess()).isTrue();
+        Assertions.assertThat(response.getCode()).isEqualTo(201);
+
+    }
+
+    @Test
+    @DisplayName("삭제한 차량을 재등록하는 경우 update 방식으로 동작한다")
+    void createCar_update() throws MalformedURLException {
+        // given
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image2", "filename2.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image3", "filename3.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image4", "filename4.png", "image/png", "dummy".getBytes()),
+                        new MockMultipartFile("image5", "filename5.png", "image/png", "dummy".getBytes())),
+                List.of(1, 2, 3, 4, 5));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Collections.emptyList());
+        given(mockCarRepository.findByCarNumberAndIsDeletedFalse(postCarDto.getCarNumber()))
+                .willReturn(Collections.emptyList());
+        given(mockModelRepository.findBySubCategory(postCarDto.getCarName()))
+                .willReturn(Optional.of(ModelEntity.builder().category("모델명").subCategory("모델명 서브모델명").build()));
+        given(mockCarRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(0L, postCarDto.getCarNumber()))
+                .willReturn(Optional.of(new CarEntity())); //
+        given(amazonS3Client.getUrl(Mockito.any(), Mockito.any())).willReturn(new URL("http://mockUrl"));
+
+        // when
+        ResponseDto response = carService.createCar(postCarDto, 0L);
+
+        // then
+        BDDMockito.verify(mockCarRepository, Mockito.times(0)).save(Mockito.any(CarEntity.class));
+        Assertions.assertThat(response.getSuccess()).isTrue();
+        Assertions.assertThat(response.getCode()).isEqualTo(201);
+    }
+
+    @Test
+    @DisplayName("차량의 모델명이 등록되어 있지 않은 경우 CAR_MODEL_NOT_FOUND 에러가 발생한다")
+    void createCar_CAR_MODEL_NOT_FOUND() {
+        // given
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of(1));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Collections.emptyList());
+        given(mockCarRepository.findByCarNumberAndIsDeletedFalse(postCarDto.getCarNumber()))
+                .willReturn(Collections.emptyList());
+        given(mockModelRepository.findBySubCategory(postCarDto.getCarName()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> carService.createCar(postCarDto, 0L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorCode.CAR_MODEL_NOT_FOUND.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("유저가 이미 등록한 차량이 있는 경우 USER_ALREADY_HAS_CAR 에러가 발생한다")
+    void createCar_USER_ALREADY_HAS_CAR() {
+        // given
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of(1));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(List.of(new CarEntity()));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> carService.createCar(postCarDto, 0L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorCode.USER_ALREADY_HAS_CAR.getErrorMessage());
+
+    }
+
+    @Test
+    @DisplayName("중복되는 차량 번호를 등록한 경우 CAR_NUMBER_DUPLICATED 에러가 발생한다")
+    void cretaeCar_CAR_NUMBER_DUPLICATED() {
+        // given
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of(1));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Collections.emptyList());
+        given(mockCarRepository.findByCarNumberAndIsDeletedFalse(postCarDto.getCarNumber()))
+                .willReturn(List.of(new CarEntity()));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> carService.createCar(postCarDto, 0L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorCode.CAR_NUMBER_DUPLICATED.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("입력받은 인덱스의 길이와 이미지의 길이가 같지 않은 경우 IMAGE_INDEX_MISMATCH 에러가 발생한다")
+    void createCar_IMAGE_INDEX_MISMATCH() {
+        // given: 이미지의 길이는 1, 인덱스의 길이는 3
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of(1, 2, 3));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Collections.emptyList());
+        given(mockCarRepository.findByCarNumberAndIsDeletedFalse(postCarDto.getCarNumber()))
+                .willReturn(Collections.emptyList());
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> carService.createCar(postCarDto, 0L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorCode.IMAGE_INDEX_MISMATCH.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("차량의 이미지를 5개 미만으로 등록한 경우 CAR_IMAGE_INSUFFICIENT 에러가 발생한다")
+    void createCar_CAR_IMAGE_INSUFFICIENT() {
+        // given
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of(1));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Collections.emptyList());
+        given(mockCarRepository.findByCarNumberAndIsDeletedFalse(postCarDto.getCarNumber()))
+                .willReturn(Collections.emptyList());
+        given(mockModelRepository.findBySubCategory(postCarDto.getCarName()))
+                .willReturn(Optional.of(ModelEntity.builder().category("모델명").subCategory("모델명 서브모델명").build()));
+        given(mockCarRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(0L, postCarDto.getCarNumber()))
+                .willReturn(Optional.of(new CarEntity())); //
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> carService.createCar(postCarDto, 0L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorCode.CAR_IMAGE_INSUFFICIENT.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 파일을 등록한 경우 INVALID_IMAGE_TYPE 에러가 발생한다")
+    void createCar_INVALID_IMAGE_TYPE() {
+        // given
+        PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
+                new PositionDto(10.0, 10.0), "설명",
+                List.of(new MockMultipartFile("image1", "filename1.txt", "text/plain", "dummy".getBytes()),
+                        new MockMultipartFile("image2", "filename2.txt", "text/plain", "dummy".getBytes()),
+                        new MockMultipartFile("image3", "filename3.txt", "text/plain", "dummy".getBytes()),
+                        new MockMultipartFile("image4", "filename4.txt", "text/plain", "dummy".getBytes()),
+                        new MockMultipartFile("image5", "filename5.txt", "text/plain", "dummy".getBytes())),
+                List.of(1, 2, 3, 4, 5));
+
+        given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Collections.emptyList());
+        given(mockCarRepository.findByCarNumberAndIsDeletedFalse(postCarDto.getCarNumber()))
+                .willReturn(Collections.emptyList());
+        given(mockModelRepository.findBySubCategory(postCarDto.getCarName()))
+                .willReturn(Optional.of(ModelEntity.builder().category("모델명").subCategory("모델명 서브모델명").build()));
+        given(mockCarRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(0L, postCarDto.getCarNumber()))
+                .willReturn(Optional.of(new CarEntity())); //
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> carService.createCar(postCarDto, 0L))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorCode.INVALID_IMAGE_TYPE.getErrorMessage());
+    }
+}

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceCreateCarTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceCreateCarTest.java
@@ -24,6 +24,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,7 +70,7 @@ public class CarServiceCreateCarTest {
         // then
         BDDMockito.verify(mockCarRepository, Mockito.times(1)).save(Mockito.any(CarEntity.class));
         Assertions.assertThat(response.getSuccess()).isTrue();
-        Assertions.assertThat(response.getCode()).isEqualTo(201);
+        Assertions.assertThat(response.getCode()).isEqualTo(HttpStatus.CREATED.value());
 
     }
 
@@ -101,12 +102,12 @@ public class CarServiceCreateCarTest {
         // then
         BDDMockito.verify(mockCarRepository, Mockito.times(0)).save(Mockito.any(CarEntity.class));
         Assertions.assertThat(response.getSuccess()).isTrue();
-        Assertions.assertThat(response.getCode()).isEqualTo(201);
+        Assertions.assertThat(response.getCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 
     @Test
     @DisplayName("차량의 모델명이 등록되어 있지 않은 경우 CAR_MODEL_NOT_FOUND 에러가 발생한다")
-    void createCar_CAR_MODEL_NOT_FOUND() {
+    void createCar_throwCarModelNotFound() {
         // given
         PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
                 new PositionDto(10.0, 10.0), "설명",
@@ -127,7 +128,7 @@ public class CarServiceCreateCarTest {
 
     @Test
     @DisplayName("유저가 이미 등록한 차량이 있는 경우 USER_ALREADY_HAS_CAR 에러가 발생한다")
-    void createCar_USER_ALREADY_HAS_CAR() {
+    void createCar_throwUserAlreadyHasCar() {
         // given
         PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
                 new PositionDto(10.0, 10.0), "설명",
@@ -145,7 +146,7 @@ public class CarServiceCreateCarTest {
 
     @Test
     @DisplayName("중복되는 차량 번호를 등록한 경우 CAR_NUMBER_DUPLICATED 에러가 발생한다")
-    void cretaeCar_CAR_NUMBER_DUPLICATED() {
+    void cretaeCar_throwCarNumberDuplicated() {
         // given
         PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
                 new PositionDto(10.0, 10.0), "설명",
@@ -164,7 +165,7 @@ public class CarServiceCreateCarTest {
 
     @Test
     @DisplayName("입력받은 인덱스의 길이와 이미지의 길이가 같지 않은 경우 IMAGE_INDEX_MISMATCH 에러가 발생한다")
-    void createCar_IMAGE_INDEX_MISMATCH() {
+    void createCar_throwImageIndexMisMatch() {
         // given: 이미지의 길이는 1, 인덱스의 길이는 3
         PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
                 new PositionDto(10.0, 10.0), "설명",
@@ -183,7 +184,7 @@ public class CarServiceCreateCarTest {
 
     @Test
     @DisplayName("차량의 이미지를 5개 미만으로 등록한 경우 CAR_IMAGE_INSUFFICIENT 에러가 발생한다")
-    void createCar_CAR_IMAGE_INSUFFICIENT() {
+    void createCar_throwCarImageInsufficient() {
         // given
         PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
                 new PositionDto(10.0, 10.0), "설명",
@@ -206,7 +207,7 @@ public class CarServiceCreateCarTest {
 
     @Test
     @DisplayName("이미지가 아닌 파일을 등록한 경우 INVALID_IMAGE_TYPE 에러가 발생한다")
-    void createCar_INVALID_IMAGE_TYPE() {
+    void createCar_throwInvalidImageType() {
         // given
         PostCarDto postCarDto = new PostCarDto("11주 1111", "모델명 서브모델명", 10.0, "가솔린", "경차", 2, 2020, 10000, "경기도 테스트 주소",
                 new PositionDto(10.0, 10.0), "설명",

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceDeleteCarTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceDeleteCarTest.java
@@ -1,0 +1,61 @@
+package com.hexacore.tayo.car;
+
+import com.hexacore.tayo.car.model.CarEntity;
+import com.hexacore.tayo.car.model.ImageEntity;
+import com.hexacore.tayo.common.ResponseDto;
+import com.hexacore.tayo.common.errors.ErrorCode;
+import com.hexacore.tayo.common.errors.GeneralException;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CarServiceDeleteCarTest {
+
+    @Mock
+    private CarRepository carRepository;
+    @Mock
+    private ImageRepository imageRepository;
+    @InjectMocks
+    private CarService carService;
+
+    @Test
+    @DisplayName("차량 삭제 요청을 하면 차량과 이미지를 soft delete 한다")
+    void deleteCar() {
+        // given
+        Long carId = 0L;
+        BDDMockito.given(carRepository.findById(carId)).willReturn(Optional.of(new CarEntity()));
+        BDDMockito.given(imageRepository.findByCar_Id(Mockito.any()))
+                .willReturn(List.of(new ImageEntity(), new ImageEntity()));
+
+        // when
+        ResponseDto response = carService.deleteCar(carId);
+
+        // then
+        BDDMockito.verify(carRepository, Mockito.times(1)).save(Mockito.any(CarEntity.class));
+        BDDMockito.verify(imageRepository, Mockito.times(2)).save(Mockito.any(ImageEntity.class));
+        Assertions.assertThat(response.getSuccess()).isTrue();
+        Assertions.assertThat(response.getCode()).isEqualTo(204);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 차량 Id를 삭제하는 경우 CAR_NOT_FOUND 에러가 발생한다")
+    void deleteCar_CAR_NOT_FOUND() {
+        // given
+        Long carId = 0L;
+        BDDMockito.given(carRepository.findById(carId)).willReturn(Optional.empty());
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> carService.deleteCar(carId))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage(ErrorCode.CAR_NOT_FOUND.getErrorMessage());
+    }
+}

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceDeleteCarTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceDeleteCarTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class CarServiceDeleteCarTest {
@@ -43,12 +44,12 @@ public class CarServiceDeleteCarTest {
         BDDMockito.verify(carRepository, Mockito.times(1)).save(Mockito.any(CarEntity.class));
         BDDMockito.verify(imageRepository, Mockito.times(2)).save(Mockito.any(ImageEntity.class));
         Assertions.assertThat(response.getSuccess()).isTrue();
-        Assertions.assertThat(response.getCode()).isEqualTo(204);
+        Assertions.assertThat(response.getCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
     @DisplayName("존재하지 않는 차량 Id를 삭제하는 경우 CAR_NOT_FOUND 에러가 발생한다")
-    void deleteCar_CAR_NOT_FOUND() {
+    void deleteCar_throwCarNotFound() {
         // given
         Long carId = 0L;
         BDDMockito.given(carRepository.findById(carId)).willReturn(Optional.empty());

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceGetCategoriesTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceGetCategoriesTest.java
@@ -1,0 +1,42 @@
+package com.hexacore.tayo.car;
+
+import com.hexacore.tayo.car.model.CategoryListDto;
+import com.hexacore.tayo.car.model.ModelEntity;
+import com.hexacore.tayo.common.DataResponseDto;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CarServiceGetCategoriesTest {
+
+    @Mock
+    private ModelRepository modelRepository;
+
+    @InjectMocks
+    private CarService carService;
+
+    @Test
+    @DisplayName("getCategories(): Model 테이블에 존재하는 모든 모델, 세부모델명을 조회한다.")
+    void getCategoriesTest() {
+        // given
+        BDDMockito.given(modelRepository.findAll())
+                .willReturn(List.of(ModelEntity.builder().category("모델명").subCategory("모델명 세부모델명").build()));
+        // when
+        DataResponseDto response = (DataResponseDto) carService.getCategories();
+
+        // then
+        Assertions.assertThat(response.getSuccess()).isTrue();
+        Assertions.assertThat(response.getCode()).isEqualTo(200);
+        Assertions.assertThat(response.getData()).isInstanceOf(CategoryListDto.class);
+        Assertions.assertThat(((CategoryListDto) response.getData()).getModels().get(0).getCategory()).isEqualTo("모델명");
+        Assertions.assertThat(((CategoryListDto) response.getData()).getModels().get(0).getSubCategory())
+                .isEqualTo("모델명 세부모델명");
+    }
+}

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceGetCategoriesTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceGetCategoriesTest.java
@@ -12,6 +12,7 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class CarServiceGetCategoriesTest {
@@ -33,7 +34,7 @@ public class CarServiceGetCategoriesTest {
 
         // then
         Assertions.assertThat(response.getSuccess()).isTrue();
-        Assertions.assertThat(response.getCode()).isEqualTo(200);
+        Assertions.assertThat(response.getCode()).isEqualTo(HttpStatus.OK.value());
         Assertions.assertThat(response.getData()).isInstanceOf(CategoryListDto.class);
         Assertions.assertThat(((CategoryListDto) response.getData()).getModels().get(0).getCategory()).isEqualTo("모델명");
         Assertions.assertThat(((CategoryListDto) response.getData()).getModels().get(0).getSubCategory())

--- a/server/src/test/java/com/hexacore/tayo/car/ModelRepositoryTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/ModelRepositoryTest.java
@@ -32,10 +32,10 @@ public class ModelRepositoryTest {
         Optional<ModelEntity> noExistResult = modelRepository.findBySubCategory("세부모델명");
 
         // then
-        Assertions.assertThat(existResult.isPresent()).isTrue();
+        Assertions.assertThat(existResult).isPresent();
         Assertions.assertThat(existResult.get().getCategory()).isEqualTo(category);
         Assertions.assertThat(existResult.get().getSubCategory()).isEqualTo(subCategory);
 
-        Assertions.assertThat(noExistResult.isEmpty()).isTrue();
+        Assertions.assertThat(noExistResult).isEmpty();
     }
 }

--- a/server/src/test/java/com/hexacore/tayo/car/ModelRepositoryTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/ModelRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.hexacore.tayo.car;
+
+import com.hexacore.tayo.car.model.ModelEntity;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ModelRepositoryTest {
+
+    @Autowired
+    private ModelRepository modelRepository;
+
+    @Test
+    @DisplayName("subCategory로 검색해서 해당하는 ModelEntity가 있는 경우 Optional<ModelEntity>를 반환하고 없으면 Optional.empty() 객체를 반환한다.")
+    void findBySubCategoryTest() {
+        // given
+        String category = "모델명";
+        String subCategory = "모델명 세부모델명";
+        ModelEntity model = new ModelEntity();
+        model.setCategory(category);
+        model.setSubCategory(subCategory);
+        modelRepository.save(model);
+
+        // when
+        Optional<ModelEntity> existResult = modelRepository.findBySubCategory(subCategory);
+        Optional<ModelEntity> noExistResult = modelRepository.findBySubCategory("세부모델명");
+
+        // then
+        Assertions.assertThat(existResult.isPresent()).isTrue();
+        Assertions.assertThat(existResult.get().getCategory()).isEqualTo(category);
+        Assertions.assertThat(existResult.get().getSubCategory()).isEqualTo(subCategory);
+
+        Assertions.assertThat(noExistResult.isEmpty()).isTrue();
+    }
+}


### PR DESCRIPTION
close #61 

## DONE

- [x] Repository 테스트 코드 작성
  - [x] CarRepository, ModelRepository 단위 테스트 코드 작성
- [x] CarController 테스트 코드 작성
  - [x] getCategories, deleteCar, createCar 메서드에 대한 단위 테스트 코드 작성
- [x] CarService 테스트 코드 작성
  - [x] CarServiceGetCategoriesTest, CarServiceCreateCarTest, CarServiceDeleteCarTest: 메서드 별로 클래스 나누어 단위 테스트 코드 작성

## 리뷰 포인트
### 테스트 코드
- Repository: JPA에서 기본으로 제공해주는 메소드 외에 Repository에 선언해서 사용한 메서드들에 대해 단위 테스트 코드 작성
  - DataJpaTest 어노테이션 사용: 경량화된 테스트 환경 구축, 트랜잭션 롤백 기능 제공
  - AutoConfigureTestDatabase 어노테이션 사용: 임베디드 데이터베이스가 아닌 MySQL 데이터베이스를 사용하기 위함
- CarService: 메서드 별로 클래스를 나누어 단위 테스트 코드 작성
  - Mockito를 이용해서 Repository, AmazonS3Client 객체를 모킹해서 서비스 자체의 로직에만 집중해서 코드 작성
- CarController: MockMvc와 Mockito를 이용해서 컨트롤러 자체의 로직에만 집중해서 테스트 코드 작성
### 그 외 리팩토링
- ModelEntity의 subCategory 컬럼에 unique 조건을 추가했습니다 -> subCategory의 값은 unique해야 하고 데이터의 수정보다 조회가 자주 일어나는 컬럼 + MySQL에서 unique 조건에 자동으로 인덱싱을 추가해주기 때문에 조회 시 성능 향상
* Valid 어노테이션을 사용해서 PostCarDto에서 필수로 넘어와야 하는 값들에 NotNull 어노테이션을 추가했습니다.
* CarService 에서 예외 처리 케이스를 추가했습니다.
  - isIndexSizeEqualsToImageSize: imageIndexes 리스트와 imageFiles 리스트 사이즈가 같은지 비교
  - uploadImage 에서 파일의 contentType이 이미지가 아닌 경우 INVALID_IMAGE_TYPE 에러 발생
