### PR TITLE
[BE] #72: Status에 대한 응답 반환 형태 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/common/response/Response.java
+++ b/server/src/main/java/com/hexacore/tayo/common/response/Response.java
@@ -24,7 +24,10 @@ public class Response {
 
     // HttpStatus에 대한 응답
     public static ResponseEntity<Response> of(HttpStatus status) {
-        return of(status, null);
+        return new ResponseEntity<>(
+                new Response(true, status.value(), status.getReasonPhrase(), null, null),
+                status
+        );
     }
 
     // ErrorCode에 대한 응답


### PR DESCRIPTION
## DONE

- [x] Response의 모든 메소드 명을 통일하며 발생한 에러 해결

## 리뷰 포인트

- 기존 status만 받아와 response를 만드는 함수에서 data의 값을 null로 설정하여 반환하던 부분이 메소드 명을 전부 통일하며 PageInfo를 만드는 메소드로 넘어가는 에러가 있었습니다. 이에 해당 부분을 직접 ResponseEntity를 만들도록 코드를 수정하였습니다.