### PR TITLE
[FE] #100: 로그인, 회원가입 api 연동

### DIFF
--- a/client/src/pages/auth/InputBox.tsx
+++ b/client/src/pages/auth/InputBox.tsx
@@ -1,16 +1,16 @@
-import { forwardRef, type FocusEventHandler, type HTMLInputTypeAttribute } from 'react';
+import { forwardRef, type HTMLInputTypeAttribute, ChangeEventHandler } from 'react';
 
 type Props = {
   title?: string;
   placeHolder: string;
   type?: HTMLInputTypeAttribute;
-  onBlur?: FocusEventHandler<HTMLInputElement>;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
   isWrong?: boolean;
   className?: string;
   errorMsg?: string;
 };
 
-const InputBox = forwardRef<HTMLInputElement, Props>(({ title, placeHolder, type = 'text', onBlur, isWrong = false, className, errorMsg }, ref) => {
+const InputBox = forwardRef<HTMLInputElement, Props>(({ title, placeHolder, type = 'text', onChange, isWrong = false, className, errorMsg }, ref) => {
   return (
     <div className='flex flex-col'>
       <div className="w-full pt-4 pb-2 flex">
@@ -22,8 +22,8 @@ const InputBox = forwardRef<HTMLInputElement, Props>(({ title, placeHolder, type
           ${className}`}
           type={type}
           placeholder={placeHolder}
-          onBlur={onBlur}
           ref={ref}
+          onChange={onChange}
         />
       </div>
 

--- a/client/src/pages/auth/InputBox.tsx
+++ b/client/src/pages/auth/InputBox.tsx
@@ -7,22 +7,27 @@ type Props = {
   onBlur?: FocusEventHandler<HTMLInputElement>;
   isWrong?: boolean;
   className?: string;
+  errorMsg?: string;
 };
 
-const InputBox = forwardRef<HTMLInputElement, Props>(({ title, placeHolder, type = 'text', onBlur, isWrong = false, className }, ref) => {
+const InputBox = forwardRef<HTMLInputElement, Props>(({ title, placeHolder, type = 'text', onBlur, isWrong = false, className, errorMsg }, ref) => {
   return (
-    <div className="w-full p-3 flex">
-      <div className="text-background-600 w-24 text-sm pl-5 flex flex-col justify-center">{title}</div>
-      <input
-        className={`
-				${isWrong ? 'ring-2 ring-danger-300' : 'focus:ring-2 focus:ring-primary-300'}
-				focus:outline-none w-4/5 h-12 text-sm py-2 pl-5 shadow-md rounded-3xl
-				${className}`}
-        type={type}
-        placeholder={placeHolder}
-        onBlur={onBlur}
-        ref={ref}
-      />
+    <div className='flex flex-col'>
+      <div className="w-full pt-4 pb-2 flex">
+        <div className="text-background-600 w-24 text-sm pl-5 flex flex-col justify-center">{title}</div>
+        <input
+          className={`
+          ${isWrong ? 'ring-2 ring-danger-300' : 'focus:ring-2 focus:ring-primary-300'}
+          focus:outline-none w-4/5 h-12 text-sm py-2 pl-5 shadow-md rounded-3xl
+          ${className}`}
+          type={type}
+          placeholder={placeHolder}
+          onBlur={onBlur}
+          ref={ref}
+        />
+      </div>
+
+      <div className='text-danger-400 h-4 text-[12px] text-end text-top pr-5'>{errorMsg}</div>
     </div>
   );
 });

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -9,10 +9,10 @@ function Login() {
   const emailInputRef = useRef<HTMLInputElement | null>(null);
   const pwdInputRef = useRef<HTMLInputElement | null>(null);
 
-  const [wrongEmail, setWrongEmail] = useState(false);
+  const [isWrongEmail, setWrongEmail] = useState(false);
   const [emailErr, setEmailErr] = useState("");
 
-  const [wrongPwd, setWrongPwd] = useState(false);
+  const [isWrongPwd, setWrongPwd] = useState(false);
   const [pwdErr, setPwdErr] = useState("");
 
   const handleLogin = async () => {
@@ -74,7 +74,7 @@ function Login() {
           title="이메일" 
           placeHolder="이메일을 입력해주세요." 
           type="email" 
-          isWrong={wrongEmail}
+          isWrong={isWrongEmail}
           errorMsg={emailErr}
         />
         <InputBox 
@@ -82,7 +82,7 @@ function Login() {
           title="비밀번호" 
           placeHolder="비밀번호를 입력해주세요." 
           type="password" 
-          isWrong={wrongPwd}
+          isWrong={isWrongPwd}
           errorMsg={pwdErr}
         />
 

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -1,31 +1,90 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import InputBox from '@/pages/auth/InputBox';
 import Button from '@/components/Button';
+import type { ResponseWithoutData, ResponseWithData, ResponseWithPagination } from "@/fetches/common/response.type";
+import { server } from "@/fetches/common/axios";
 
 function Login() {
   const emailInputRef = useRef<HTMLInputElement | null>(null);
   const pwdInputRef = useRef<HTMLInputElement | null>(null);
 
-  const handleLogin = () => {
-    const userEmail = emailInputRef.current?.value;
-    const userPwd = pwdInputRef.current?.value;
-    if (userEmail == '') {
-      alert('아이디를 입력해주세요');
-    } else if (userPwd == '') {
-      alert('비밀번호를 입력해주세요');
-    } else {
-      // 서버에 로그인 요청
+  const [wrongEmail, setWrongEmail] = useState(false);
+  const [emailErr, setEmailErr] = useState("");
+
+  const [wrongPwd, setWrongPwd] = useState(false);
+  const [pwdErr, setPwdErr] = useState("");
+
+  const handleLogin = async () => {
+    const userEmail: string = emailInputRef.current?.value || '';
+    const userPwd: string = pwdInputRef.current?.value || '';
+
+    if (!checkEmailEmpty(userEmail) && !checkPwdEmpty(userPwd)) {
+      const response = await server.post<ResponseWithoutData>('/auth/login', {
+        data: {
+          email: userEmail,
+          password: userPwd,
+        }
+      });
+      if (response.success) {
+        window.location.href = '/';
+      } else {
+        setPwdInputErr("올바른 이메일과 비밀번호를 입력해주세요.");
+      }
     }
   };
+
+  // 이메일 입력란 비어있는지 확인
+  const checkEmailEmpty = (email: string): boolean => {
+    if (email === '') {
+      setWrongEmail(true);
+      setEmailErr("이메일을 입력해주세요.");
+      return true;
+    }
+
+    setWrongEmail(false);
+    setEmailErr("")
+    return false;
+  };
+
+  // 비밀번호 입력란 비어있는지 확인
+  const checkPwdEmpty = (pwd: string): boolean => {
+    if (pwd === '') {
+      setPwdInputErr("비밀번호를 입력해주세요.");
+      return true;
+    }
+
+    setWrongPwd(false);
+    setPwdErr("")
+    return false;
+  };
+
+  const setPwdInputErr = (errorMsg: string): void => {
+    setWrongPwd(true);
+    setPwdErr(errorMsg)
+  }
 
   return (
     <div className="flex justify-center pt-16">
       <div className="flex w-5/12 flex-col">
         <div className={`p-8 text-2xl`}>로그인</div>
 
-        <InputBox ref={emailInputRef} title="아이디" placeHolder="아이디를 입력해주세요." type="email" />
-        <InputBox ref={pwdInputRef} title="비밀번호" placeHolder="비밀번호를 입력해주세요." type="password" />
+        <InputBox 
+          ref={emailInputRef} 
+          title="이메일" 
+          placeHolder="이메일을 입력해주세요." 
+          type="email" 
+          isWrong={wrongEmail}
+          errorMsg={emailErr}
+        />
+        <InputBox 
+          ref={pwdInputRef} 
+          title="비밀번호" 
+          placeHolder="비밀번호를 입력해주세요." 
+          type="password" 
+          isWrong={wrongPwd}
+          errorMsg={pwdErr}
+        />
 
         <div className="flex justify-end pr-14 pt-8">
           <Link to="/auth/signup" className="pr-8">

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import InputBox from '@/pages/auth/InputBox';
 import Button from '@/components/Button';
-import type { ResponseWithoutData, ResponseWithData, ResponseWithPagination } from "@/fetches/common/response.type";
+import type { ResponseWithoutData } from "@/fetches/common/response.type";
 import { server } from "@/fetches/common/axios";
 
 function Login() {

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -4,8 +4,11 @@ import InputBox from '@/pages/auth/InputBox';
 import Button from '@/components/Button';
 import type { ResponseWithoutData } from "@/fetches/common/response.type";
 import { server } from "@/fetches/common/axios";
+import { useNavigate } from 'react-router-dom';
 
 function Login() {
+  const navigate = useNavigate();
+
   const emailInputRef = useRef<HTMLInputElement | null>(null);
   const pwdInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -27,7 +30,7 @@ function Login() {
         }
       });
       if (response.success) {
-        window.location.href = '/';
+        navigate("/");
       } else {
         setPwdInputErr("올바른 이메일과 비밀번호를 입력해주세요.");
       }

--- a/client/src/pages/auth/SignUp.tsx
+++ b/client/src/pages/auth/SignUp.tsx
@@ -3,12 +3,15 @@ import InputBox from '@/pages/auth/InputBox';
 import Button from '@/components/Button';
 import type { ResponseWithoutData } from "@/fetches/common/response.type";
 import { server } from "@/fetches/common/axios";
+import { useNavigate } from 'react-router-dom';
 
 const emailPattern: RegExp = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 // const passwordPattern: RegExp = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{6,}$/;
 const phoneNumberPattern: RegExp = /^\d{3}-\d{4}-\d{4}$/;
 
 function SignUp() {
+  const navigate = useNavigate();
+
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [profilePicture, setProfilePicture] = useState<string | null>(null);
 
@@ -54,7 +57,8 @@ function SignUp() {
 
       if (response.success) {
         // 회원가입 성공시 로그인 페이지로
-        window.location.href = '/auth/login';
+        navigate("/auth/login");
+        
       } else {
         // 에러 메세지 띄우기
         setEmailInputErr(response.message);
@@ -116,6 +120,27 @@ function SignUp() {
     setPhoneErr("000-0000-0000 형식으로 입력해주세요.");
     return false;
   }
+
+  const phoneNumChange = () => {
+    if (phoneNumInputRef.current) {
+      const phoneNumber = phoneNumInputRef.current.value;
+
+      const phonePattern1: RegExp = /^\d{3}$/;
+      const phonePattern2: RegExp = /^\d{3}-\d{4}$/;
+      const phonePattern3: RegExp = /^\d{3}-\d{4}-\d{4}\d/;
+
+      if (phonePattern1.test(phoneNumber)) {
+        phoneNumInputRef.current.value = phoneNumber + '-';
+      } else if (phonePattern2.test(phoneNumber)) {
+        phoneNumInputRef.current.value = phoneNumber + '-';
+      }
+
+      // 마지막 문자가 숫자가 아니면 제거
+      if (!/\d$/.test(phoneNumber.slice(-1)) || phonePattern3.test(phoneNumber)) {
+        phoneNumInputRef.current.value = phoneNumber.slice(0, -1);
+      }
+    }
+  } 
 
   const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -191,6 +216,7 @@ function SignUp() {
           placeHolder="010-1234-5678"
           isWrong={isWrongPhoneNum}
           errorMsg={phoneErr}
+          onChange={phoneNumChange}
         />
 
         <div className="flex justify-end pb-10 pr-14 pt-8">

--- a/client/src/pages/auth/SignUp.tsx
+++ b/client/src/pages/auth/SignUp.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, ChangeEvent } from 'react';
 import InputBox from '@/pages/auth/InputBox';
 import Button from '@/components/Button';
+import type { ResponseWithoutData } from "@/fetches/common/response.type";
+import { server } from "@/fetches/common/axios";
 
 const emailPattern: RegExp = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 // const passwordPattern: RegExp = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{6,}$/;
@@ -26,7 +28,7 @@ function SignUp() {
   const [phoneErr, setPhoneErr] = useState("");
   const [isWrongPhoneNum, setIsWrongPhoneNum] = useState(false);
 
-  const handleSignUp = () => {
+  const handleSignUp = async () => {
     const email: string = emailInputRef.current?.value || '';
     const password: string = pwdInputRef.current?.value || '';
     const name: string = nameInputRef.current?.value || '';
@@ -34,9 +36,36 @@ function SignUp() {
     const profileImg: File | null = fileInputRef.current?.files?.[0] || null;
 
     if (checkEmail(email) && checkPwd(password) && checkName(name) && checkPhoneNum(phoneNumber)) {
-      
+      const formData = new FormData();
+      formData.append('email', email);
+      formData.append('password', password);
+      formData.append('name', name);
+      formData.append('phoneNumber', phoneNumber);
+      if (profileImg !== null) {
+        formData.append('profileImg', profileImg);
+      }
+
+      const response = await server.post<ResponseWithoutData>('/auth/signup', {
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        },
+        data: formData
+      });
+
+      if (response.success) {
+        // 회원가입 성공시 로그인 페이지로
+        window.location.href = '/auth/login';
+      } else {
+        // 에러 메세지 띄우기
+        setEmailInputErr(response.message);
+      }
     }
   };
+
+  const setEmailInputErr = (errorMsg: string): void => {
+    setIsWrongEmail(true)
+    setEmailErr(errorMsg);
+  }
 
   // 이메일 형식에 맞는지 확인
   const checkEmail = (email: string): boolean => {

--- a/client/src/pages/auth/SignUp.tsx
+++ b/client/src/pages/auth/SignUp.tsx
@@ -3,7 +3,7 @@ import InputBox from '@/pages/auth/InputBox';
 import Button from '@/components/Button';
 
 const emailPattern: RegExp = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
-const passwordPattern: RegExp = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{6,}$/;
+// const passwordPattern: RegExp = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{6,}$/;
 const phoneNumberPattern: RegExp = /^\d{3}-\d{4}-\d{4}$/;
 
 function SignUp() {
@@ -11,23 +11,82 @@ function SignUp() {
   const [profilePicture, setProfilePicture] = useState<string | null>(null);
 
   const emailInputRef = useRef<HTMLInputElement | null>(null);
-  const [isValidEmail, setIsValidEmail] = useState(false);
+  const [emailErr, setEmailErr] = useState("");
+  const [isWrongEmail, setIsWrongEmail] = useState(false);
 
   const pwdInputRef = useRef<HTMLInputElement | null>(null);
-  const [isValidPassword, setIsValidPassword] = useState(false);
+  const [pwdErr, setPwdErr] = useState("");
+  const [isWrongPassword, setIsWrongPassword] = useState(false);
 
   const nameInputRef = useRef<HTMLInputElement | null>(null);
-  const [isValidName, setIsValidName] = useState(false);
-
-  const nicknameInputRef = useRef<HTMLInputElement | null>(null);
-  const [isValidNickname, setIsValidNickname] = useState(false);
+  const [nameErr, setNameErr] = useState("");
+  const [isWrongName, setIsWrongName] = useState(false);
 
   const phoneNumInputRef = useRef<HTMLInputElement | null>(null);
-  const [isValidPhoneNum, setIsValidPhoneNum] = useState(false);
+  const [phoneErr, setPhoneErr] = useState("");
+  const [isWrongPhoneNum, setIsWrongPhoneNum] = useState(false);
 
   const handleSignUp = () => {
-    // 서버에 회원가입 요청
+    const email: string = emailInputRef.current?.value || '';
+    const password: string = pwdInputRef.current?.value || '';
+    const name: string = nameInputRef.current?.value || '';
+    const phoneNumber: string = phoneNumInputRef.current?.value || '';
+    const profileImg: File | null = fileInputRef.current?.files?.[0] || null;
+
+    if (checkEmail(email) && checkPwd(password) && checkName(name) && checkPhoneNum(phoneNumber)) {
+      
+    }
   };
+
+  // 이메일 형식에 맞는지 확인
+  const checkEmail = (email: string): boolean => {
+    if (emailPattern.test(email)) {
+      setIsWrongEmail(false)
+      setEmailErr("");
+      return true;
+    }
+    setIsWrongEmail(true)
+    setEmailErr("이메일 형식에 맞게 입력해주세요");
+    return false;
+  }
+
+  // 비밀번호 형식에 맞는지 확인
+  const checkPwd = (pwd: string): boolean => {
+    // if (!passwordPattern.test(pwd)) {
+    if (pwd === "") {
+      setIsWrongPassword(true)
+      // setPwdErr("영어, 숫자, 기호 포함 길이 6이상 입력해주세요");
+      setPwdErr("비밀번호를 입력해주세요.");
+      return false;
+    }
+    setIsWrongPassword(false)
+    setPwdErr("");
+    return true;
+  }
+
+  // 이름 입력했는지 확인
+  const checkName = (name: string): boolean => {
+    if (name === "") {
+      setIsWrongName(true)
+      setNameErr("이름을 입력해주세요.");
+      return false;
+    }
+    setIsWrongName(false)
+    setNameErr("");
+    return true;
+  }
+
+  // 전화번호 형식에 맞는지 확인
+  const checkPhoneNum = (phoneNum: string): boolean => {
+    if (phoneNumberPattern.test(phoneNum)) {
+      setIsWrongPhoneNum(false)
+      setPhoneErr("");
+      return true;
+    }
+    setIsWrongPhoneNum(true)
+    setPhoneErr("000-0000-0000 형식으로 입력해주세요.");
+    return false;
+  }
 
   const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -43,14 +102,10 @@ function SignUp() {
     }
   };
 
-  const handleButtonClick = () => {
+  const handleImgButtonClick = () => {
     if (fileInputRef.current) {
       fileInputRef.current.click();
     }
-  };
-
-  const checkInputValues = (): boolean => {
-    return isValidEmail && isValidPassword && isValidName && isValidNickname && isValidPhoneNum;
   };
 
   return (
@@ -61,13 +116,13 @@ function SignUp() {
         <div className="flex justify-between pb-4">
           <div className="w-44"></div>
           {profilePicture === null ? (
-            <img src="/defaultProfile.png" className="h-32 w-32 rounded-full shadow-md" onClick={handleButtonClick} />
+            <img src="/defaultProfile.png" className="h-32 w-32 rounded-full shadow-md" onClick={handleImgButtonClick} />
           ) : (
-            <img src={profilePicture} className="h-32 w-32 rounded-full shadow-md" onClick={handleButtonClick} />
+            <img src={profilePicture} className="h-32 w-32 rounded-full shadow-md" onClick={handleImgButtonClick} />
           )}
           <div className="flex flex-col justify-end pb-2 pr-10">
             {profilePicture === null ? (
-              <button onClick={handleButtonClick} className="h-10 w-24 rounded-full text-sm font-semibold text-primary-500 ring-2 ring-primary-500">
+              <button onClick={handleImgButtonClick} className="h-10 w-24 rounded-full text-sm font-semibold text-primary-500 ring-2 ring-primary-500">
                 사진 등록
               </button>
             ) : (
@@ -83,49 +138,34 @@ function SignUp() {
           title="이메일"
           placeHolder="tayo@tayo.com"
           type="email"
-          onBlur={() => {
-            if (!emailInputRef.current) return;
-            setIsValidEmail(emailPattern.test(emailInputRef.current.value));
-          }}
+          isWrong={isWrongEmail}
+          errorMsg={emailErr}
         />
         <InputBox
           ref={pwdInputRef}
           title="비밀번호"
-          placeHolder="영어, 숫자, 기호 포함 길이 6이상 비밀번호"
+          placeHolder="영어, 숫자, 기호 포함 길이 6이상"
           type="password"
-          onBlur={() => {
-            if (!pwdInputRef.current) return;
-            setIsValidPassword(passwordPattern.test(pwdInputRef.current.value));
-          }}
+          isWrong={isWrongPassword}
+          errorMsg={pwdErr}
         />
         <InputBox
           ref={nameInputRef}
           title="이름"
           placeHolder="김타요"
-          onBlur={() => {
-            setIsValidName(nameInputRef.current?.value !== '');
-          }}
-        />
-        <InputBox
-          ref={nicknameInputRef}
-          title="닉네임"
-          placeHolder="타요 닉네임"
-          onBlur={() => {
-            setIsValidNickname(nicknameInputRef.current?.value !== '');
-          }}
+          isWrong={isWrongName}
+          errorMsg={nameErr}
         />
         <InputBox
           ref={phoneNumInputRef}
           title="전화번호"
           placeHolder="010-1234-5678"
-          onBlur={() => {
-            if (!phoneNumInputRef.current) return;
-            setIsValidPhoneNum(phoneNumberPattern.test(phoneNumInputRef.current.value));
-          }}
+          isWrong={isWrongPhoneNum}
+          errorMsg={phoneErr}
         />
 
         <div className="flex justify-end pb-10 pr-14 pt-8">
-          <Button text="회원가입" className="h-12 w-44" type={checkInputValues() ? 'enabled' : 'disabled'} isRounded onClick={handleSignUp} />
+          <Button text="회원가입" className="h-12 w-44" isRounded onClick={handleSignUp} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
* close #100
## DONE

- [x] 로그인 api 연동
   * 회원가입 성공 시에 메인 페이지로 이동
- [x] 회원가입 api 연동
   * 닉네임 제거
   * 회원가입 성공 시에 로그인 페이지로 이동
- [x] 입력 값이 틀린 경우 빨간 박스 + 아래에 에러 메세지 보여주도록

## 스크린 샷
### 회원가입
영문, 숫자, 기호 포함 6자 이상 입력해야 했는데,
개발과정에서 유저 생성해보고 테스트해보는 과정에서 어려울 것 같아 비밀번호는 패턴 체크 일단 주석처리 해놓았습니다.

회원가입 성공하면 로그인 페이지로 이동하게 했습니다.

* 형식에 맞지 않거나 입력하지 않은 경우 요청 안보냄
* 같은 이메일로 가입한 유저가 있는 경우 중복된 유저입니다.

https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/80809782/de55be8a-306e-46ed-88ef-09837638a209

### 로그인
* 아이디나 비밀번호 입력하지 않은 경우 요청 보내지 않음 - 입력해주세요.
* 가입하지 않은 유저 or 비밀번호 틀린 경우 or 서버 에러 - 올바른 이메일, 비밀번호를 입력해주세요.

https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/80809782/d46f41ec-6437-46c5-96e3-93d22339c0b0

