### PR TITLE
[FE, BE] #110: jwt 토큰을 로컬 스토리지에 저장하도록 수정

### DIFF
--- a/client/src/fetches/auth/auth.type.ts
+++ b/client/src/fetches/auth/auth.type.ts
@@ -1,0 +1,13 @@
+export type LoginResponse = { 
+  tokens: {
+    accessToken: string; 
+    refreshToken: string ;
+  };
+  loginUserInfo: {
+    userId: number;
+    name: string;
+    email: string;
+    phoneNumber: string;
+    profileImgUrl: string
+  }
+};

--- a/client/src/fetches/common/axios.ts
+++ b/client/src/fetches/common/axios.ts
@@ -7,9 +7,11 @@ const apiPrefix = import.meta.env.VITE_API_PREFIX ?? '/';
 
 const axiosInstance = axios.create({
   baseURL: `${baseURL}${apiPrefix}`,
-  headers: {
-    'Authorization': 'Bearer ' + localStorage.getItem("accessToken"),
-  },
+});
+
+axiosInstance.interceptors.request.use(function (config) {
+  config.headers.Authorization = `Bearer ${localStorage.getItem("accessToken")}`;
+  return config;
 });
 
 axiosInstance.interceptors.response.use(

--- a/client/src/fetches/common/axios.ts
+++ b/client/src/fetches/common/axios.ts
@@ -7,6 +7,9 @@ const apiPrefix = import.meta.env.VITE_API_PREFIX ?? '/';
 
 const axiosInstance = axios.create({
   baseURL: `${baseURL}${apiPrefix}`,
+  headers: {
+    'Authorization': 'Bearer ' + localStorage.getItem("accessToken"), // 필요에 따라 인증 토큰 추가
+  },
 });
 
 axiosInstance.interceptors.response.use(

--- a/client/src/fetches/common/axios.ts
+++ b/client/src/fetches/common/axios.ts
@@ -14,9 +14,7 @@ axiosInstance.interceptors.request.use(
   function (config) {
     // 헤더에 Authorization 설정
     const accessToken = localStorage.getItem('accessToken');
-    console.log("in");
     if (accessToken) {
-      console.log(accessToken);
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;

--- a/client/src/fetches/common/axios.ts
+++ b/client/src/fetches/common/axios.ts
@@ -8,7 +8,7 @@ const apiPrefix = import.meta.env.VITE_API_PREFIX ?? '/';
 const axiosInstance = axios.create({
   baseURL: `${baseURL}${apiPrefix}`,
   headers: {
-    'Authorization': 'Bearer ' + localStorage.getItem("accessToken"), // 필요에 따라 인증 토큰 추가
+    'Authorization': 'Bearer ' + localStorage.getItem("accessToken"),
   },
 });
 

--- a/client/src/fetches/common/axios.ts
+++ b/client/src/fetches/common/axios.ts
@@ -9,10 +9,23 @@ const axiosInstance = axios.create({
   baseURL: `${baseURL}${apiPrefix}`,
 });
 
-axiosInstance.interceptors.request.use(function (config) {
-  config.headers.Authorization = `Bearer ${localStorage.getItem("accessToken")}`;
-  return config;
-});
+// 요청 인터셉터 추가
+axiosInstance.interceptors.request.use(
+  function (config) {
+    // 헤더에 Authorization 설정
+    const accessToken = localStorage.getItem('accessToken');
+    console.log("in");
+    if (accessToken) {
+      console.log(accessToken);
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  function (error) {
+    // 요청이 실패한 경우에 대한 처리
+    return Promise.reject(error);
+  }
+);
 
 axiosInstance.interceptors.response.use(
   (response) => response.data,

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -8,7 +8,6 @@ import { useNavigate } from 'react-router-dom';
 import { LoginResponse } from '@/fetches/auth/auth.type';
 
 function Login() {
-  document.cookie = `a=bbbb; path=/;`;
   const navigate = useNavigate();
 
   const emailInputRef = useRef<HTMLInputElement | null>(null);

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -2,11 +2,13 @@ import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import InputBox from '@/pages/auth/InputBox';
 import Button from '@/components/Button';
-import type { ResponseWithoutData } from "@/fetches/common/response.type";
+import type { ResponseWithData } from "@/fetches/common/response.type";
 import { server } from "@/fetches/common/axios";
 import { useNavigate } from 'react-router-dom';
+import { LoginResponse } from '@/fetches/auth/auth.type';
 
 function Login() {
+  document.cookie = `a=bbbb; path=/;`;
   const navigate = useNavigate();
 
   const emailInputRef = useRef<HTMLInputElement | null>(null);
@@ -19,17 +21,19 @@ function Login() {
   const [pwdErr, setPwdErr] = useState("");
 
   const handleLogin = async () => {
-    const userEmail: string = emailInputRef.current?.value || '';
-    const userPwd: string = pwdInputRef.current?.value || '';
+    const userEmail: string = emailInputRef.current?.value ?? '';
+    const userPwd: string = pwdInputRef.current?.value ?? '';
 
     if (!checkEmailEmpty(userEmail) && !checkPwdEmpty(userPwd)) {
-      const response = await server.post<ResponseWithoutData>('/auth/login', {
+      const response = await server.post<ResponseWithData<LoginResponse>>('/auth/login', {
         data: {
           email: userEmail,
           password: userPwd,
         }
       });
       if (response.success) {
+        setCookie("accessToken", response.data.tokens.accessToken, "/");
+        setCookie("refreshToken", response.data.tokens.refreshToken, "/");
         navigate("/");
       } else {
         setPwdInputErr("올바른 이메일과 비밀번호를 입력해주세요.");
@@ -37,6 +41,10 @@ function Login() {
     }
   };
 
+  const setCookie = (name: string, value: string, path: string): void => {
+    document.cookie = `${name}=${value}; path=${path};`;
+  };
+  
   // 이메일 입력란 비어있는지 확인
   const checkEmailEmpty = (email: string): boolean => {
     if (email === '') {

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -32,17 +32,13 @@ function Login() {
         }
       });
       if (response.success) {
-        setCookie("accessToken", response.data.tokens.accessToken, "/");
-        setCookie("refreshToken", response.data.tokens.refreshToken, "/");
+        localStorage.setItem("accessToken", response.data.tokens.accessToken);
+        localStorage.setItem("refreshToken", response.data.tokens.refreshToken);
         navigate("/");
       } else {
         setPwdInputErr("올바른 이메일과 비밀번호를 입력해주세요.");
       }
     }
-  };
-
-  const setCookie = (name: string, value: string, path: string): void => {
-    document.cookie = `${name}=${value}; path=${path};`;
   };
   
   // 이메일 입력란 비어있는지 확인

--- a/server/src/main/java/com/hexacore/tayo/auth/AuthController.java
+++ b/server/src/main/java/com/hexacore/tayo/auth/AuthController.java
@@ -1,7 +1,6 @@
 package com.hexacore.tayo.auth;
 
 import com.hexacore.tayo.auth.jwt.dto.GetTokenResponseDto;
-import com.hexacore.tayo.common.UriPath;
 import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
 import com.hexacore.tayo.common.response.Response;
@@ -9,11 +8,8 @@ import com.hexacore.tayo.user.dto.LoginRequestDto;
 import com.hexacore.tayo.user.dto.LoginResponseDto;
 import com.hexacore.tayo.user.dto.SignUpRequestDto;
 import com.hexacore.tayo.user.model.User;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -50,7 +46,7 @@ public class AuthController {
 
     // 로그아웃
     @GetMapping("/logout")
-    public ResponseEntity<Response> logOut(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<Response> logOut(HttpServletRequest request) {
         authService.logOut((Long) request.getAttribute(USER_ID));
 
         return Response.of(HttpStatus.OK);
@@ -58,7 +54,7 @@ public class AuthController {
 
     // 회원 탈퇴
     @DeleteMapping("/users")
-    public ResponseEntity<Response> deleteUser(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<Response> deleteUser(HttpServletRequest request) {
         authService.delete((Long) request.getAttribute(USER_ID));
 
         return Response.of(HttpStatus.OK);
@@ -66,7 +62,7 @@ public class AuthController {
 
     // 엑세스 토큰 재발급
     @GetMapping("/refresh")
-    public ResponseEntity<Response> refresh(HttpServletRequest request, HttpServletResponse response) {dd
+    public ResponseEntity<Response> refresh(HttpServletRequest request) {
         GetTokenResponseDto tokenResponseDto = authService.refresh((Long) request.getAttribute(USER_ID));
 
         return Response.of(HttpStatus.OK, tokenResponseDto);

--- a/server/src/main/java/com/hexacore/tayo/auth/AuthController.java
+++ b/server/src/main/java/com/hexacore/tayo/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.hexacore.tayo.auth;
 
+import com.hexacore.tayo.auth.jwt.dto.GetTokenResponseDto;
 import com.hexacore.tayo.common.UriPath;
 import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
@@ -65,11 +66,10 @@ public class AuthController {
 
     // 엑세스 토큰 재발급
     @GetMapping("/refresh")
-    public ResponseEntity<Response> refresh(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<Response> refresh(HttpServletRequest request, HttpServletResponse response) {dd
+        GetTokenResponseDto tokenResponseDto = authService.refresh((Long) request.getAttribute(USER_ID));
 
-        String newAccessToken = authService.refresh((Long) request.getAttribute(USER_ID));
-
-        return Response.of(HttpStatus.OK, newAccessToken);
+        return Response.of(HttpStatus.OK, tokenResponseDto);
     }
 
     @GetMapping("/login/test")

--- a/server/src/main/java/com/hexacore/tayo/auth/AuthService.java
+++ b/server/src/main/java/com/hexacore/tayo/auth/AuthService.java
@@ -103,7 +103,7 @@ public class AuthService {
                 .build();
 
         return LoginResponseDto.builder()
-                .tokenResponseDto(tokenResponseDto)
+                .tokens(tokenResponseDto)
                 .loginUserInfo(loginUserInfo)
                 .build();
     }
@@ -112,11 +112,9 @@ public class AuthService {
         User expiredUser = userRepository.findById(userId).orElseThrow(() ->
                 new AuthException(ErrorCode.USER_NOT_FOUND));
 
-        GetTokenResponseDto tokenResponseDto = GetTokenResponseDto.builder()
+        return GetTokenResponseDto.builder()
                 .accessToken(jwtProvider.createAccessToken(expiredUser))
                 .build();
-
-        return tokenResponseDto;
     }
 
     private GetUserInfoResponseDto getLoginUserInfo(User user) {

--- a/server/src/main/java/com/hexacore/tayo/auth/AuthService.java
+++ b/server/src/main/java/com/hexacore/tayo/auth/AuthService.java
@@ -1,6 +1,7 @@
 package com.hexacore.tayo.auth;
 
 import com.hexacore.tayo.auth.jwt.RefreshTokenService;
+import com.hexacore.tayo.auth.jwt.dto.GetTokenResponseDto;
 import com.hexacore.tayo.auth.jwt.util.JwtProvider;
 import com.hexacore.tayo.util.Encryptor;
 import com.hexacore.tayo.car.model.Car;
@@ -96,10 +97,13 @@ public class AuthService {
         }
 
         GetUserInfoResponseDto loginUserInfo = getLoginUserInfo(loginUser);
-
-        return LoginResponseDto.builder()
+        GetTokenResponseDto tokenResponseDto = GetTokenResponseDto.builder()
                 .accessToken(jwtProvider.createAccessToken(loginUser))
                 .refreshToken(jwtProvider.createRefreshToken(loginUser.getId()))
+                .build();
+
+        return LoginResponseDto.builder()
+                .tokenResponseDto(tokenResponseDto)
                 .loginUserInfo(loginUserInfo)
                 .build();
     }

--- a/server/src/main/java/com/hexacore/tayo/auth/AuthService.java
+++ b/server/src/main/java/com/hexacore/tayo/auth/AuthService.java
@@ -108,11 +108,15 @@ public class AuthService {
                 .build();
     }
 
-    public String refresh(Long userId) {
+    public GetTokenResponseDto refresh(Long userId) {
         User expiredUser = userRepository.findById(userId).orElseThrow(() ->
                 new AuthException(ErrorCode.USER_NOT_FOUND));
 
-        return jwtProvider.createAccessToken(expiredUser);
+        GetTokenResponseDto tokenResponseDto = GetTokenResponseDto.builder()
+                .accessToken(jwtProvider.createAccessToken(expiredUser))
+                .build();
+
+        return tokenResponseDto;
     }
 
     private GetUserInfoResponseDto getLoginUserInfo(User user) {

--- a/server/src/main/java/com/hexacore/tayo/auth/jwt/dto/GetTokenResponseDto.java
+++ b/server/src/main/java/com/hexacore/tayo/auth/jwt/dto/GetTokenResponseDto.java
@@ -1,0 +1,13 @@
+package com.hexacore.tayo.auth.jwt.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetTokenResponseDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/server/src/main/java/com/hexacore/tayo/config/InterceptorConfig.java
+++ b/server/src/main/java/com/hexacore/tayo/config/InterceptorConfig.java
@@ -8,7 +8,6 @@ import com.hexacore.tayo.interceptor.LoggingInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 

--- a/server/src/main/java/com/hexacore/tayo/interceptor/AuthenticationInterceptor.java
+++ b/server/src/main/java/com/hexacore/tayo/interceptor/AuthenticationInterceptor.java
@@ -3,8 +3,6 @@ package com.hexacore.tayo.interceptor;
 import com.hexacore.tayo.auth.jwt.util.JwtParser;
 import com.hexacore.tayo.common.UriPath;
 import com.hexacore.tayo.util.RequestParser;
-import com.hexacore.tayo.common.errors.AuthException;
-import com.hexacore.tayo.common.errors.ErrorCode;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
 
-import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/server/src/main/java/com/hexacore/tayo/interceptor/AuthenticationInterceptor.java
+++ b/server/src/main/java/com/hexacore/tayo/interceptor/AuthenticationInterceptor.java
@@ -52,7 +52,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String accessToken = RequestParser.getToken(request, accessTokenCookieName);
+        String accessToken = RequestParser.getAuthorizationToken(request);
         Claims claims = jwtParser.getClaims(accessToken);
 
         request.setAttribute(USER_ID, Long.valueOf((Integer) claims.get(USER_ID)));

--- a/server/src/main/java/com/hexacore/tayo/user/dto/LoginResponseDto.java
+++ b/server/src/main/java/com/hexacore/tayo/user/dto/LoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.hexacore.tayo.user.dto;
 
+import com.hexacore.tayo.auth.jwt.dto.GetTokenResponseDto;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,8 +8,7 @@ import lombok.Getter;
 @Builder
 public class LoginResponseDto {
 
-    private String accessToken;
-    private String refreshToken;
+    private GetTokenResponseDto tokenResponseDto;
     private GetUserInfoResponseDto loginUserInfo;
 
 }

--- a/server/src/main/java/com/hexacore/tayo/user/dto/LoginResponseDto.java
+++ b/server/src/main/java/com/hexacore/tayo/user/dto/LoginResponseDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Builder
 public class LoginResponseDto {
 
-    private GetTokenResponseDto tokenResponseDto;
+    private GetTokenResponseDto tokens;
     private GetUserInfoResponseDto loginUserInfo;
 
 }

--- a/server/src/main/java/com/hexacore/tayo/util/RequestParser.java
+++ b/server/src/main/java/com/hexacore/tayo/util/RequestParser.java
@@ -25,4 +25,22 @@ public class RequestParser {
         // 요청 헤더의 쿠키에 토큰이 없는 경우 예외 발생
         throw new AuthException(ErrorCode.INVALID_JWT_TOKEN);
     }
+
+    /**
+     * 요청 헤더 Authorization 에서 토큰을 읽어 반환
+     *
+     * @param request 요청
+     * @return 토큰
+     */
+    public static String getAuthorizationToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            // Bearer 제외한 값 리턴
+            return authorizationHeader.substring(7);
+        }
+
+        // 요청 헤더 Authorization 에 정상적인 토큰이 없는 경우
+        throw new AuthException(ErrorCode.INVALID_JWT_TOKEN);
+    }
 }

--- a/server/src/main/java/com/hexacore/tayo/util/RequestParser.java
+++ b/server/src/main/java/com/hexacore/tayo/util/RequestParser.java
@@ -35,12 +35,12 @@ public class RequestParser {
     public static String getAuthorizationToken(HttpServletRequest request) {
         String authorizationHeader = request.getHeader("Authorization");
 
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            // Bearer 제외한 값 리턴
-            return authorizationHeader.substring(7);
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            // 요청 헤더 Authorization 에 정상적인 토큰이 없는 경우
+            throw new AuthException(ErrorCode.INVALID_JWT_TOKEN);
         }
 
-        // 요청 헤더 Authorization 에 정상적인 토큰이 없는 경우
-        throw new AuthException(ErrorCode.INVALID_JWT_TOKEN);
+        // Bearer 제외한 값 리턴
+        return authorizationHeader.substring("Bearer ".length());
     }
 }


### PR DESCRIPTION
- close #110 
## DONE
로그인 요청시 엑세스 토큰과 리프레시 바디로 받아 Document.setcookie를 통해 쿠키에 jwt 토큰을 설정해주도록 수정합니다.

하지만 쿠키 설정 이슈로 인해
Authorization 헤더에 넘기는 것으로 수정했습니다.
써드 파티 쿠키는 브라우저에 설정이 안되는 문제와, 해당 쿠키가 서버에 전송되지 않는 문제가 있는데,
이는 나중에 자세히 알아보도록 하겠습니다!

- [x] 로그인 요청시 엑세스 토큰과 리프레시 바디로 받아 localStorage에 저장
- [x] 모든 api 요청 헤더에 localStorage에 저장되어 있는 엑세스 토큰은 Authorization 헤더에 전송하도록 수정

추후에 Authorization 헤더, 쿠키의 차이에 대해 자세히 알아볼 예정입미다!

