### PR TITLE
[BE] #118: 인터셉터 허용 메소드, 경로 추가

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/interceptor/AuthenticationInterceptor.java
+++ b/server/src/main/java/com/hexacore/tayo/interceptor/AuthenticationInterceptor.java
@@ -28,8 +28,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     private static final String USER_ID = "userId";
     private static final String USER_NAME = "userName";
     private static final String HTTP_GET = "GET";
+    private static final String HTTP_OPTIONS = "OPTIONS";
 
-    private static final String[] whiteUrlList = {"/cars/[0-9]*"};
+    private static final String[] whiteUrlList = {"/cars", "/cars/[0-9]*", "/categories"};
 
     /**
      * @param request  HTTP 요청
@@ -44,7 +45,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         String httpMethod = request.getMethod();
         String url = request.getRequestURI();
         if (handler.getClass().equals(ResourceHttpRequestHandler.class) ||
-                (httpMethod.equals(HTTP_GET) && canPass(url))
+                (httpMethod.equals(HTTP_GET) && canPass(url)) || httpMethod.equals(HTTP_OPTIONS)
         ) {
             return true;
         }


### PR DESCRIPTION
- close #118

## DONE

- [x] 사용자 인증을 거치지 않는 메소드와 경로를 추가합니다.

## 설명

- 요청을 보낼 때, 해당 요청이 안전한 요청인지 확인하기 위해 OPTIONS 메소드로 미리 서버에 요청을 보내보는데, 이에 대해서도 사용자 인증을 거치는 문제가 발생하여 OPTIONS 요청에 대해서는 인터셉터를 거치지 않도록 합니다.
- 차량을 검색하는 api는 인터셉트를 통과하도록 합니다.
