### PR TITLE
[BE] #125: 예약 정보 업데이트 시 validation 버그 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
@@ -159,15 +159,16 @@ public class ReservationService {
             LocalDate startDate = carDateRange.getStartDate();
             LocalDate endDate = carDateRange.getEndDate();
 
-            if (!localDateInclusiveAfter(endDate, returnDateTime.toLocalDate()) ||
-                    !localDateInclusiveBefore(startDate, rentDateTime.toLocalDate())) {
+            // 포함되는 예약 가능 구간을 찾을 때 까지는 continue;
+            if (startDate.isAfter(rentDateTime.toLocalDate()) || endDate.isBefore(rentDateTime.toLocalDate())) {
                 continue;
             }
+
             for (Reservation reservation : carDateRange.getReservations()) {
-                if (reservation.getStatus() == ReservationStatus.READY ||
-                        reservation.getStatus() == ReservationStatus.USING) {
-                    if (!reservation.getReturnDateTime().isBefore(rentDateTime)
-                            || !reservation.getRentDateTime().isAfter(returnDateTime)) {
+                if (reservation.getStatus() == ReservationStatus.READY
+                        || reservation.getStatus() == ReservationStatus.USING) {
+                    if (!(reservation.getRentDateTime().isAfter(returnDateTime)
+                            || reservation.getReturnDateTime().isBefore(rentDateTime))) {
                         throw new GeneralException(ErrorCode.RESERVATION_ALREADY_READY_OR_USING);
                     }
                 }
@@ -175,13 +176,5 @@ public class ReservationService {
             return carDateRange;
         }
         throw new GeneralException(ErrorCode.RESERVATION_DATE_NOT_IN_RANGE);
-    }
-
-    private boolean localDateInclusiveBefore(LocalDate startDate, LocalDate rentDate) {
-        return startDate.isEqual(rentDate) || startDate.isBefore(rentDate);
-    }
-
-    private boolean localDateInclusiveAfter(LocalDate endDate, LocalDate returnDate) {
-        return endDate.isEqual(returnDate) || endDate.isAfter(returnDate);
     }
 }

--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
@@ -167,8 +167,8 @@ public class ReservationService {
             for (Reservation reservation : carDateRange.getReservations()) {
                 if (reservation.getStatus() == ReservationStatus.READY
                         || reservation.getStatus() == ReservationStatus.USING) {
-                    if (!(reservation.getRentDateTime().isAfter(returnDateTime)
-                            || reservation.getReturnDateTime().isBefore(rentDateTime))) {
+                    if (!(reservation.getRentDateTime().toLocalDate().isAfter(returnDateTime.toLocalDate())
+                            || reservation.getReturnDateTime().toLocalDate().isBefore(rentDateTime.toLocalDate()))) {
                         throw new GeneralException(ErrorCode.RESERVATION_ALREADY_READY_OR_USING);
                     }
                 }


### PR DESCRIPTION
## DONE

- [x] 예약 가능 구간 검증에 대한 로직 버그 수정

## 리뷰 포인트
### 기존 코드
```java
for (CarDateRange carDateRange : carDateRanges) {
    LocalDate startDate = carDateRange.getStartDate();
    LocalDate endDate = carDateRange.getEndDate();

    // 포함되는 예약 가능 구간을 찾을 때 까지는 continue;
    if (!localDateInclusiveAfter(endDate, returnDateTime.toLocalDate()) ||
            !localDateInclusiveBefore(startDate, rentDateTime.toLocalDate())) {
        continue;
    }

    for (Reservation reservation : carDateRange.getReservations()) {
        if (reservation.getStatus() == ReservationStatus.READY ||
                reservation.getStatus() == ReservationStatus.USING) {
            if (!reservation.getReturnDateTime().isBefore(rentDateTime)
                    || !reservation.getRentDateTime().isAfter(returnDateTime)) {
                throw new GeneralException(ErrorCode.RESERVATION_ALREADY_READY_OR_USING);
            }
        }
    }
    return carDateRange;
}
```

- 기존 로직에서는 반납일이 항상 예약이 되어있는 시작 날짜보다 앞인 경우에만 예약이 가능하도록 되어 있었습니다. 하지만, [예약 완료 시작, 예약 완료 끝] 다음 구간에 [대여일, 반납일] 해당 구간이 오는 경우에도 예약이 가능한 경우이므로 해당 로직을 수정하였습니다.

### 수정된 코드
```java
for (CarDateRange carDateRange : carDateRanges) {
    LocalDate startDate = carDateRange.getStartDate();
    LocalDate endDate = carDateRange.getEndDate();

    // 포함되는 예약 가능 구간을 찾을 때 까지는 continue;
    if (startDate.isAfter(rentDateTime.toLocalDate()) || endDate.isBefore(rentDateTime.toLocalDate())) {
        continue;
    }

    for (Reservation reservation : carDateRange.getReservations()) {
        if (reservation.getStatus() == ReservationStatus.READY
                || reservation.getStatus() == ReservationStatus.USING) {
            if (!(reservation.getRentDateTime().isAfter(returnDateTime)
                    || reservation.getReturnDateTime().isBefore(rentDateTime))) {
                throw new GeneralException(ErrorCode.RESERVATION_ALREADY_READY_OR_USING);
            }
        }
    }
    return carDateRange;
}
```
- 예약이 가능한 상황을 생각해 보면 [rentDateTime, returnDateTime] 구간이 [Reservation_start, Reservation_end] 구간보다 앞에 있거나 (즉, Reservation_start가 returnDateTime보다 뒤에 있는 경우) [Reservation_start, Reservation_end] 구간이 [rentDateTime, returnDateTime] 구간보다 앞에 있는 경우 (즉, Reservation_end가 rentDateTime보다 앞에 있는 경우) 이기 때문에 해당 케이스를 제외한 나머지의 경우 Error를 발생시켜 줘야 합니다.
- 또한, 들어온 예약이 포함되는 예약 가능한 구간을 찾을 때도 [Reservation_start, rentDateTime, returnDateTime, Reservation_end] 이런 순서로 포함관계가 되어있어야 하기 때문에 R.start <= rent && return <= R.end의 부정인 R.start > rent || R.end < return인 경우에는 continue;가 되도록 수정하였습니다.
