### PR TITLE
[BE] #138: DB 변경사항 반영하여 차량 삭제 API 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -161,14 +161,15 @@ public class CarService {
             throw new GeneralException(ErrorCode.CAR_HAVE_ACTIVE_RESERVATIONS);
         }
 
-        // 차량 isDeleted = true
+        // 차량 삭제: isDeleted = true
         car.setIsDeleted(true);
         carRepository.save(car);
 
-        // 이미지 isDeleted = true
+        // 이미지 삭제
         carImageRepository.findByCar_Id(car.getId()).forEach((image) -> {
-            image.setIsDeleted(true);
-            carImageRepository.save(image);
+            // s3 버킷 객체 삭제
+            s3Manager.deleteImage(image.getUrl());
+            carImageRepository.delete(image);
         });
     }
 

--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -153,9 +153,15 @@ public class CarService {
     /* 차량 삭제 */
     @Transactional
     public void deleteCar(Long carId) {
-        // 차량 isDeleted = true
         Car car = carRepository.findById(carId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.CAR_NOT_FOUND));
+
+        // 차량에 연결된 READY, USING 상태의 예약이 있는 경우 삭제불가
+        if (isCarHavingReservation(car.getReservations())) {
+            throw new GeneralException(ErrorCode.CAR_HAVE_ACTIVE_RESERVATIONS);
+        }
+
+        // 차량 isDeleted = true
         car.setIsDeleted(true);
         carRepository.save(car);
 
@@ -328,5 +334,12 @@ public class CarService {
 
         result.add(new CarDateRangeDto(currentCarDateRange));
         return result;
+    }
+
+    /* READY, USING 상태의 예약이 있는지 체크 */
+    private Boolean isCarHavingReservation(List<Reservation> reservations) {
+        return reservations.stream().anyMatch(reservation ->
+                reservation.getStatus() == ReservationStatus.READY ||
+                reservation.getStatus() == ReservationStatus.USING);
     }
 }

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     IMAGE_INDEX_MISMATCH(HttpStatus.BAD_REQUEST, "이미지 개수와 인덱스 개수가 일치하지 않습니다."),
     INVALID_CAR_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 차량 타입입니다."),
     INVALID_FUEL_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 연료 타입입니다."),
+    CAR_HAVE_ACTIVE_RESERVATIONS(HttpStatus.BAD_REQUEST, "차량에 활성화된 예약 내역이 있어 차량을 삭제할 수 없습니다."),
 
     DATE_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, "날짜 구간이 맞지 않습니다."),
     DATE_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, "날짜 형식이 맞지 않습니다."),


### PR DESCRIPTION
close(#138)

## DONE

- [x] 차량 삭제 API에서 차량에 연결된 진행중인 예약이 있는지 체크하는 로직 추가
- [x] 이미지 삭제 하드 딜리트 방식으로 수정 (S3 버킷의 객체도 삭제)

## 리뷰 포인트

- 차량을 삭제하기 전 차량에 연결된 예약 중 상태가 READY 혹은 USING인 것이 있으면 삭제하지 못하고 에러를 발생하게 수정했습니다.
- 프론트 호스트 관리 페이지에서 해당 에러를 받으면 사용자에게 차량을 삭제하려면 예약을 모두 삭제한 뒤 재시도하라고 알려줘야할 것 같습니다. @jomulagy 지훈님 호스트 관리 페이지 담당이신 것 같아서 태그합니다 :)
- 차량 수정 부분에서 현재 이미지 소프트 딜리트 방식으로 구현하고 있어서 CarImage 엔티티 클래스에서 isDeleted 필드를 아직 삭제하지 않았습니다. 해당 부분 수정하시고 삭제해주시면 감사하겠습니다. @jomulagy 