### PR TITLE
[BE] #157: 예약 가능 날짜 업데이트 API 버그 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -211,8 +211,12 @@ public class CarService {
             } else if (reservationStartDate.isAfter(dateRangeEndDate)) { // 다음 예약 가능한 구간 확인
                 dateRangeIdx++;
             } else {
-                throw new GeneralException(ErrorCode.CAR_DATE_RANGE_ALREADY_HAS_RESERVATIONS);
+                throw new GeneralException(ErrorCode.CAR_DATE_RANGE_NOT_CONTAIN_RESERVATIONS);
             }
+        }
+
+        if (reservationIdx < reservations.size()) { // 예약 가능한 구간이 남지 않았는데 예약이 남은 경우
+            throw new GeneralException(ErrorCode.CAR_DATE_RANGE_NOT_CONTAIN_RESERVATIONS);
         }
 
         // 기존 구간을 모두 삭제한다.
@@ -341,6 +345,6 @@ public class CarService {
     private Boolean isCarHavingReservation(List<Reservation> reservations) {
         return reservations.stream().anyMatch(reservation ->
                 reservation.getStatus() == ReservationStatus.READY ||
-                reservation.getStatus() == ReservationStatus.USING);
+                        reservation.getStatus() == ReservationStatus.USING);
     }
 }

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
     CAR_UPDATED_BY_OTHERS(HttpStatus.BAD_REQUEST, "해당 차량을 소유한 사용자만 차량 정보를 변경할 수 있습니다."),
     INVALID_CAR_DATE_RANGE_DUPLICATED(HttpStatus.BAD_REQUEST, "예약 가능일자에 겹치는 부분이 있습니다."),
     CAR_DATE_RANGE_UPDATED_BY_OTHERS(HttpStatus.BAD_REQUEST, "해당 차량을 소유한 사용자만 예약 가능일자를 변경할 수 있습니다."),
-    CAR_DATE_RANGE_ALREADY_HAS_RESERVATIONS(HttpStatus.BAD_REQUEST, "변경할 예약 가능일자에 이미 예약대기 혹은 사용중인 예약이 있습니다."),
+    CAR_DATE_RANGE_NOT_CONTAIN_RESERVATIONS(HttpStatus.BAD_REQUEST, "변경할 예약 가능일자에 예약대기 혹은 사용중인 예약을 포함하는 일정이 없습니다."),
     USER_ALREADY_HAS_CAR(HttpStatus.BAD_REQUEST, "유저가 이미 차량을 등록했습니다."),
     IMAGE_INDEX_MISMATCH(HttpStatus.BAD_REQUEST, "이미지 개수와 인덱스 개수가 일치하지 않습니다."),
     INVALID_CAR_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 차량 타입입니다."),


### PR DESCRIPTION
close #157 

# DONE

- [x] 예약 가능 날짜 업데이트 버그 수정 

# 리뷰 포인트

- 기존: updateDateRanges에서 모든 예약 가능 구간 이후의 예약이 있는지를 검증하지 못함
- 투 포인터를 사용한 검증 방식에서 예약 가능한 구간이 남지 않았는데 예약이 남은 경우를 검증하지 못한 부분 수정