### PR TITLE
[FE] #165: 1970-01-01 안 보이도록 수정

### DIFF
--- a/client/src/pages/cars/CarDetail.tsx
+++ b/client/src/pages/cars/CarDetail.tsx
@@ -221,14 +221,14 @@ function CarDetail() {
           <div className="grid grid-cols-2 gap-0 overflow-hidden rounded-xl border-[1px] border-background-300">
             <label className="flex flex-col gap-1 border-b-[0.5px] border-r-[0.5px] border-background-300 p-3" htmlFor="rentHourSelect">
               <p className="text-xs font-medium">대여일</p>
-              <p className="text-background-500">
-                {dateToString(dateRange[0])}
+              <p className="text-background-500 min-h-6">
+                {dateToString(dateRange[0]) === dateToString(new Date(0)) ? '' : dateToString(dateRange[0])}
               </p>
             </label>
             <label className="flex flex-col gap-1 border-b-[0.5px] border-l-[0.5px] border-background-300 p-3" htmlFor="rentHourSelect">
               <p className="text-xs font-medium">반납일</p>
-              <p className="text-background-500">
-                {dateToString(dateRange[1])}
+              <p className="text-background-500 min-h-6">
+                {dateToString(dateRange[1]) === dateToString(new Date(0)) ? '' : dateToString(dateRange[1])}
               </p>
             </label>
             <div className="gap-1 border-r-[0.5px] border-t-[0.5px] border-background-300 p-3">


### PR DESCRIPTION
## DONE
- [x] 차량 상세 정보 페이지에서 예약 날짜 선택 안 했을 때 1970-01-01 나오는 버그 수정

## 리뷰 포인트

- 예약 날짜를 선택하지 않았을 때 기본적으로 1970-01-01이라는 날짜로 표기되었는데 해당 부분을 빈 스트링이 표기되도록 수정하였습니다.

## 스크린 샷
### Before
<img width="1796" alt="스크린샷 2024-02-18 오후 6 04 29" src="https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/90602694/a506dad6-9ebc-49bc-816f-4f2fcd875d99">


### After
<img width="1796" alt="after" src="https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/90602694/f4c9601e-16f4-4a33-a6a0-ef43230ce688">
