### PR TITLE
[FE] #177: 대여시각과 반납시각이 일치할 경우 예약하지 못 하도록 수정

### DIFF
--- a/client/src/pages/cars/CarDetail.tsx
+++ b/client/src/pages/cars/CarDetail.tsx
@@ -106,6 +106,12 @@ function CarDetail() {
     const rentDate = dateTimeToString(startDate);
     const returnDate = dateTimeToString(endDate);
 
+    // 만약 rentDate와 returnDate가 동일할 경우 예약 불가능
+    if(rentDate === returnDate) {
+      alert("최소 예약 단위는 1시간입니다.") // TODO: 모달 컴포넌트 만들면 모달창 띄우는 방식으로 수정
+      return;
+    }
+
     const reservationData = {
       carId: data.carId,
       rentDateTime: rentDate,


### PR DESCRIPTION
## DONE

- [x] 차량 예약 시 대여 시각과 반납 시각이 동일할 경우 예약을 못 하도록 수정해야 함

## 리뷰 포인트

- 대여 날짜 및 시간과 반납 날짜 및 시간이 정확하게 일치할 경우 예약을 하지 못 하도록 수정하였습니다.
- 예외 상황에 대해 현재는 alert로 경고 창을 띄우고 있는데 전체적으로 어떻게 예외 상황을 핸들링하면 좋을지 논의가 필요해 보입니다.