### PR TITLE
[BE] #176: 차량 삭제 시 연결된 car_date_range 하드 딜리트

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/CarController.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarController.java
@@ -72,8 +72,9 @@ public class CarController {
     }
 
     @DeleteMapping("/{carId}")
-    public ResponseEntity<Response> deleteCar(@PathVariable Long carId) {
-        carService.deleteCar(carId);
+    public ResponseEntity<Response> deleteCar(HttpServletRequest request, @PathVariable Long carId) {
+        Long userId = (Long) request.getAttribute("userId");
+        carService.deleteCar(carId, userId);
         return Response.of(HttpStatus.NO_CONTENT);
     }
 


### PR DESCRIPTION
close(#176)

## DONE

- [x] 차량 삭제 시 유저 검증 로직, car_date_range cascade 딜리트 로직 추가

## 리뷰 포인트

현재 차량 삭제 API 에서 차량을 soft delete 처리하고 연결된 이미지를 hard delete 처리하고 있지만, 차량에 매핑된 reservation과 car_date_range에 대한 처리는 하지 않고 있습니다. reservation은 차량이 삭제되어도 게스트가 예약 내역에서 확인할 수 있어야 하기에 따로 처리를 하지 않지만, car_date_range의 경우에는 추후 유저가 같은 번호의 차량을 재등록했을때 이전에 설정했던 car_date_range가 불러와지는 것은 논리적으로 맞지 않으므로 차량을 삭제할 때 연결된 car_date_range도 모두 하드 딜리트 하도록 수정했습니다.
