### PR TITLE
[BE] #193:  toString() 메서드 중복 에러

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/dto/SearchCarsResultDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/SearchCarsResultDto.java
@@ -16,19 +16,6 @@ public class SearchCarsResultDto {
 
     @Override
     public String toString() {
-        return "SearchCarsResultDto{" +
-                "id=" + id +
-                ", subcategory=" + subcategory +
-                ", imageUrl=" + imageUrl +
-                ", address=" + address +
-                ", mileage=" + mileage +
-                ", capacity=" + capacity +
-                ", feePerHour=" + feePerHour +
-                '}';
-    }
-
-    @Override
-    public String toString() {
         return "{"
                 + "id=" + id
                 + ", subcategory='" + subcategory + '\''


### PR DESCRIPTION
close(#193)

## DONE

- [x] SearchCarsResultDto 클래스의 toString 메서드 중복 에러 해결

## 리뷰 포인트

- dev 브랜치의 SearchCarsResultDto 에서 toString() 메서드가 중복으로 선언되어 있어서 에러가 발생합니다. 수현님이 작성한 toString 메서드만 남기고 삭제했습니다.
