### PR TITLE
[BE] #195: 호스트 차량 정보 조회 api 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -21,7 +21,6 @@ import com.hexacore.tayo.reservation.model.ReservationStatus;
 import com.hexacore.tayo.user.model.User;
 import com.hexacore.tayo.util.S3Manager;
 import jakarta.transaction.Transactional;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -30,7 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.IntStream;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -127,7 +125,7 @@ public class CarService {
         Car car = carRepository.findByIdAndIsDeletedFalse(carId)
                 // 차량 조회가 안 되는 경우
                 .orElseThrow(() -> new GeneralException(ErrorCode.CAR_NOT_FOUND));
-        return GetCarResponseDto.of(car);
+        return GetCarResponseDto.guest(car);
     }
 
     /* 차량 정보 수정 */
@@ -153,7 +151,7 @@ public class CarService {
 
     /* 차량 삭제 */
     @Transactional
-    public void deleteCar(Long carId) {
+    public void deleteCar(Long carId, Long userId) {
         Car car = carRepository.findByIdAndIsDeletedFalse(carId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.CAR_NOT_FOUND));
 
@@ -185,7 +183,7 @@ public class CarService {
     /* 예약 가능 날짜 수정 */
     @Transactional
     public void updateDateRanges(Long hostUserId, Long carId,
-                                 CarDateRangesDto carDateRangesDto) {
+            CarDateRangesDto carDateRangesDto) {
         // 차량 조회가 안 되는 경우
         Car car = carRepository.findByIdAndIsDeletedFalse(carId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.CAR_NOT_FOUND));

--- a/server/src/main/java/com/hexacore/tayo/car/dto/GetCarResponseDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/GetCarResponseDto.java
@@ -58,7 +58,7 @@ public class GetCarResponseDto {
 
     private final String description;
 
-    private GetCarResponseDto(Car car) {
+    private GetCarResponseDto(Car car, List<List<String>> carDateRanges) {
         this.id = car.getId();
         this.carName = car.getSubcategory().getName();
         this.carNumber = car.getCarNumber();
@@ -71,15 +71,43 @@ public class GetCarResponseDto {
         this.feePerHour = car.getFeePerHour();
         this.address = car.getAddress();
         this.description = car.getDescription();
-        this.carDateRanges = getCarAvailableDates(car);
+        this.carDateRanges = carDateRanges;
         this.host = new GetUserSimpleResponseDto(car.getOwner());
     }
 
-    public static GetCarResponseDto of(Car car) {
-        return new GetCarResponseDto(car);
+    public static GetCarResponseDto host(Car car) {
+        return new GetCarResponseDto(car, getCarAvailableDatesForHost(car.getCarDateRanges()));
     }
 
-    private List<List<String>> getCarAvailableDates(Car car) {
+    public static GetCarResponseDto guest(Car car) {
+        return new GetCarResponseDto(car, getCarAvailableDatesForGuest(car));
+    }
+
+    private static List<List<String>> getCarAvailableDatesForHost(List<CarDateRange> carDateRanges) {
+        List<List<String>> carAvailableDates = new ArrayList<>();
+
+        for (CarDateRange carDateRange : carDateRanges) {
+            LocalDate start = carDateRange.getStartDate();
+            LocalDate end = carDateRange.getEndDate();
+
+            // 만약 end가 현재 날짜보다 전일 경우 추가하지 않음
+            if (end.isBefore(LocalDate.now())) {
+                continue;
+            }
+
+            // 만약 start가 현재 날짜보다 전일 경우 start를 현재 날짜로 업데이트
+            if (start.isBefore(LocalDate.now())) {
+                start = LocalDate.now();
+            }
+
+            carAvailableDates.add(List.of(start.toString(), end.toString()));
+        }
+
+        return carAvailableDates.stream().sorted(Comparator.comparing(list -> list.get(0)))
+                .collect(Collectors.toList());
+    }
+
+    private static List<List<String>> getCarAvailableDatesForGuest(Car car) {
         List<List<String>> carAvailableDates = new ArrayList<>();
         List<Reservation> sortedReservations = car.getReservations().stream()
                 .filter((reservation -> reservation.getStatus() != ReservationStatus.CANCEL))

--- a/server/src/main/java/com/hexacore/tayo/user/UserService.java
+++ b/server/src/main/java/com/hexacore/tayo/user/UserService.java
@@ -6,11 +6,11 @@ import com.hexacore.tayo.car.model.Car;
 import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
 import com.hexacore.tayo.user.dto.GetUserCustomerKeyResponseDto;
-import com.hexacore.tayo.util.S3Manager;
-import com.hexacore.tayo.user.dto.UpdateUserRequestDto;
 import com.hexacore.tayo.user.dto.GetUserInfoResponseDto;
+import com.hexacore.tayo.user.dto.UpdateUserRequestDto;
 import com.hexacore.tayo.user.model.User;
 import com.hexacore.tayo.util.Encryptor;
+import com.hexacore.tayo.util.S3Manager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -55,7 +55,7 @@ public class UserService {
     public GetCarResponseDto getUserCar(Long userId) {
         Car car = carRepository.findByOwner_IdAndIsDeletedFalse(userId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_CAR_NOT_EXISTS));
-        return GetCarResponseDto.of(car);
+        return GetCarResponseDto.host(car);
     }
 
     private GetUserInfoResponseDto getUserInfo(User user) {


### PR DESCRIPTION
## DONE

- [x] 호스트 차량 정보 조회 api 수정

## 리뷰 포인트

- 기존 코드에서는 호스트가 차량 상세 정보를 조회할 때와 게스트가 차량 상세 정보를 조회할 때 모두 예약 가능한 구간이 reservation 테이블에 예약이 걸려있는 날짜 구간이 제외되고 있었습니다. 하지만, 호스트가 본인의 차량 관리를 할 때에는 호스트가 열어둔 모든 예약 가능 구간이 필요하기 때문에 해당 로직을 분리하였습니다.

- close #195 
