### PR TITLE
[FE] #183: 차량 등록/수정 페이지 관련 수정

### DIFF
--- a/client/src/pages/hosts/HostRegister.tsx
+++ b/client/src/pages/hosts/HostRegister.tsx
@@ -58,8 +58,11 @@ const calculateCarType = (CC: string) => {
   if (CCvalue < 1000) {
     return '경차';
   }
-  if (CCvalue < 1600) {
+  if (CCvalue < 1300) {
     return '소형차';
+  }
+  if (CCvalue < 1600) {
+    return '준중형차';
   }
   if (CCvalue < 2000) {
     return '중형차';
@@ -134,12 +137,12 @@ function HostRegister() {
   const formatCurrency = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.currentTarget.value.length === 0 || !feeRef.current) return;
 
-    const currencyValue = e.currentTarget.value ?? 0; // NaN일때 0으로 변환
+    const currencyValue = fee ?? 0; // NaN일때 0으로 변환
     const currencyValueNumber = Number(currencyValue.replace(/,/g, ''));
 
     // 0 혹은 NaN이면 빈 칸으로 바꾼다.
     if (currencyValueNumber === 0 || Number.isNaN(currencyValueNumber)) {
-      feeRef.current.value = '';
+      setFee('');
       return;
     }
 
@@ -148,7 +151,7 @@ function HostRegister() {
     // 0 3개마다 , 표시
 
     if (feeRef.current) {
-      feeRef.current.value = formattedCurrency;
+      setFee(formattedCurrency);
       // 입력 창의 커서를 ",000"의 앞의 위치로 강제한다.
       feeRef.current.selectionStart = e.currentTarget.value.length - 4;
       feeRef.current.selectionEnd = e.currentTarget.value.length - 4;

--- a/client/src/pages/hosts/HostRegister.tsx
+++ b/client/src/pages/hosts/HostRegister.tsx
@@ -41,6 +41,17 @@ type positionLatLng = {
   lng: string;
 };
 
+// 데이터허브 API의 연료 형식을 DB에 맞게 변경한다.
+const convertFuelType = (fuel: string) => {
+  if (fuel === '가솔린') return '휘발유';
+  if (fuel === '디젤') return '경유';
+  if (fuel === 'LPG') return 'LPG';
+  if (fuel === '전기') return '전기';
+  if (fuel === '수소전기') return '수소';
+
+  return '';
+};
+
 // 배기량을 기준으로 차량 종류를 구별한다.
 const calculateCarType = (CC: string) => {
   const CCvalue = Number(CC);
@@ -188,7 +199,7 @@ function HostRegister() {
         capacity: Number.parseInt(responseCarCapacity),
         carName: responseCarName,
         carNumber: registerNumber,
-        fuel: responseCarFuel,
+        fuel: convertFuelType(responseCarFuel),
         mileage: Number.parseFloat(responseCarMileage),
         type: calculateCarType(responseData.CC),
         year: Number.parseInt(responseCarYear),

--- a/server/src/main/java/com/hexacore/tayo/car/dto/GetCarResponseDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/GetCarResponseDto.java
@@ -62,7 +62,9 @@ public class GetCarResponseDto {
         this.id = car.getId();
         this.carName = car.getSubcategory().getName();
         this.carNumber = car.getCarNumber();
-        this.imageUrls = car.getCarImages().stream().map(CarImage::getUrl).toList();
+        this.imageUrls = car.getCarImages().stream()
+                .sorted(Comparator.comparing(CarImage::getOrderIdx))
+                .map(CarImage::getUrl).toList();
         this.mileage = car.getMileage();
         this.fuel = car.getFuel().getValue();
         this.type = car.getType().getValue();


### PR DESCRIPTION
close #183 
## DONE

- [x] 차량의 연료 종류 (가솔린, 전기 ...) 등을 DB에 적절한 문자열로 변환
- [ ] 서버가 꺼져있거나 서버에게 보낸 요청이 실패할 때의 페이지 처리

## 리뷰 포인트

- BE 코드를 수정한 부분은 GetCarResponseDto에서 OrderIdx가 정렬된 상태로 전달하도록 수정한 부분입니다.
- 사진을 추가/변경하면 대여료의 값이 변경되는 점을 수정
- 다음과 같은 코드로 데이터허브 API의 연료 형식을 재분류하였습니다.
  ```typescript
  const convertFuelType = (fuel: string) => {
    if (fuel === '가솔린') return '휘발유';
    if (fuel === '디젤') return '경유';
    if (fuel === 'LPG') return 'LPG';
    if (fuel === '전기') return '전기';
    if (fuel === '수소전기') return '수소';
  
    return '';
  };
  ```
