### PR TITLE
[BE] #205: SearchCarsDto에서 type이 null일 경우 CarType enum을 사용하지 않음

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/dto/SearchCarsDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/SearchCarsDto.java
@@ -22,13 +22,14 @@ public class SearchCarsDto {
     private final Integer maxPrice;
 
     static public SearchCarsDto of(SearchCarsRequestDto searchCarsRequestDto) {
+        String type = searchCarsRequestDto.getType();
         return SearchCarsDto.builder()
                 .distance(searchCarsRequestDto.getDistance())
                 .position(new Position(searchCarsRequestDto.getLat(), searchCarsRequestDto.getLng()))
                 .startDate(searchCarsRequestDto.getStartDate())
                 .endDate(searchCarsRequestDto.getEndDate())
                 .party(searchCarsRequestDto.getParty())
-                .type(CarType.of(searchCarsRequestDto.getType()))
+                .type(type == null ? null : CarType.valueOf(type))
                 .categoryId(searchCarsRequestDto.getCategoryId())
                 .subcategoryId(searchCarsRequestDto.getSubcategoryId())
                 .minPrice(searchCarsRequestDto.getMinPrice())


### PR DESCRIPTION
- #205 

## DONE

- [x] 검색 조건으로 입력된 `type`이 `CarType` enum으로 파싱이 안될 경우 검색 조건에서 제외

## 리뷰 포인트

- #204  

위 PR의 변경 사항으로 인해 검색 조건에 `CarType`을 입력하지 않을 경우 예외가 응답됩니다.
`CarType`이 입력되지 않았을 경우 검색 조건에서 제외하고 검색하는 것이 정상 동작입니다.