### PR TITLE
[FE] #208: 

### DIFF
--- a/client/src/components/svgs/LoadingCircle.tsx
+++ b/client/src/components/svgs/LoadingCircle.tsx
@@ -1,0 +1,12 @@
+function LoadingCircle() {
+  return (
+    <div
+      className='border-current inline-block h-5 w-5 animate-spin rounded-full border-4 border-solid border-r-transparent align-[-0.125em] text-white motion-reduce:animate-[spin_1.5s_linear_infinite]'
+      role='status'>
+      <span className='!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]'>Loading...</span>
+    </div>
+  );
+}
+
+export default LoadingCircle;
+

--- a/client/src/pages/hosts/HostRegister.tsx
+++ b/client/src/pages/hosts/HostRegister.tsx
@@ -333,7 +333,7 @@ function HostRegister() {
           <form method='POST' action='https://datahub-dev.scraping.co.kr/assist/common/carzen/CarAllInfoInquiry' onSubmit={onSubmitCheckCarNumber}>
             <div className='flex justify-center'>
               <div className='flex w-5/12 items-center justify-between rounded-3xl bg-white px-6 py-2'>
-                <input className='w-full p-3 text-2xl focus:outline-none' name='REGINUMBER' type='text' placeholder='12가3456' />
+                <input className='w-full p-3 text-2xl focus:outline-none' name='REGINUMBER' type='text' placeholder='12가3456' autoComplete='off' />
                 <input type='image' src='/search-button.png' width={48} height={48} />
               </div>
             </div>

--- a/client/src/pages/hosts/HostRegister.tsx
+++ b/client/src/pages/hosts/HostRegister.tsx
@@ -7,7 +7,7 @@ import AddressButton from './AddressButton';
 import { server } from '@/fetches/common/axios';
 import { ResponseWithoutData } from '@/fetches/common/response.type';
 import axios from 'axios';
-import { CarDetailJsonData } from '@/fetches/cars/cars.type';
+import { HostRegisterLoaderData } from './hostsRoutes';
 
 const GET_CAR_INFO_API_URL = 'https://datahub-dev.scraping.co.kr/assist/common/carzen/CarAllInfoInquiry';
 
@@ -28,12 +28,6 @@ type CarDetailByApi = {
   mileage: number;
   type: string;
   year: number;
-};
-
-type loaderData = {
-  username: string;
-  isUpdate: boolean;
-  carDetail: CarDetailJsonData | undefined;
 };
 
 type positionLatLng = {
@@ -83,7 +77,16 @@ function HostRegister() {
   const [addressMessage, setAddressMessage] = useState<string | null>(null);
   const feeRef = useRef<HTMLInputElement>(null);
   const navigator = useNavigate();
-  const userCarInfo = useLoaderData() as loaderData;
+  const userCarInfo = useLoaderData() as HostRegisterLoaderData;
+
+  // 서버에 접근할 수 없거나 요청에 대한 응답에 오류가 발생할 경우
+  if (userCarInfo === null) {
+    return <div>{'서버에 연결할 수 없습니다. 다시 시도해 주세요.'}</div>;
+  }
+  // 인증이 안된 경우 빈 페이지를 보여준다. -> 로그인 페이지로 리다이렉트
+  if (userCarInfo.errMessage === '로그인이 필요한 요청입니다.') {
+    return <div></div>;
+  }
 
   // 만약 수정에 대한 사항이라면 차량 번호 조회 페이지를 생략한다.
   useEffect(() => {


### PR DESCRIPTION
close #208 

## DONE

- [x] 차량 등록/수정 페이지가 서버 오류일 시 페이지를 보여주도록 수정

추가 사항

- [x] 차량번호로 차량 정보 조회(외부 API 사용)시 오래걸리는 것을 반영해 로딩 Spinner 추가

## 리뷰 포인트

- 서버에 접근하지 못하면 (서버가 다운되는 등) 에러 메시지를 보여주도록 했습니다.
- 로그인이 필요한 페이지이기 때문에 로그인 페이지로 리다이렉트되는 동안 빈 페이지로 보여지도록 했습니다.
- 데이터허브 API에 소요시간이 걸리기 때문에 로딩 spinner를 추가했습니다.

## 스크린 샷
<img width="1715" alt="스크린샷 2024-02-20 오후 2 15 32" src="https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/148764580/fc4ce1f6-fa6b-4b21-9b4f-14f5432864bd">

https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/148764580/6468b1e8-ca5d-4ef0-be3a-c9c75f569f03

