### PR TITLE
[BE] #207: 신고하기 및 예약 정렬 기준 추가

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 
     REPORTED_BY_OTHERS(HttpStatus.BAD_REQUEST, "해당 예약의 호스트만 신고가 가능합니다."),
     REPORTED_NOT_USING_RESERVATION(HttpStatus.BAD_REQUEST, "반납이 지연된 예약만 신고가 가능합니다."),
+    ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "해당 예약은 이미 신고되었습니다."),
 
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스 입니다"),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -52,6 +52,9 @@ public enum ErrorCode {
     INVALID_POSITION(HttpStatus.BAD_REQUEST, "위치 정보가 올바르지 않습니다."),
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "결제 금액이 올바르지 않습니다."),
 
+    REPORTED_BY_OTHERS(HttpStatus.BAD_REQUEST, "해당 예약의 호스트만 신고가 가능합니다."),
+    REPORTED_NOT_USING_RESERVATION(HttpStatus.BAD_REQUEST, "반납이 지연된 예약만 신고가 가능합니다."),
+
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스 입니다"),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
 

--- a/server/src/main/java/com/hexacore/tayo/report/ReportController.java
+++ b/server/src/main/java/com/hexacore/tayo/report/ReportController.java
@@ -1,0 +1,37 @@
+package com.hexacore.tayo.report;
+
+import com.hexacore.tayo.common.response.Response;
+import com.hexacore.tayo.report.dto.CreateReportDto;
+import com.hexacore.tayo.report.dto.CreateReportRequestDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<Response> createReport(HttpServletRequest request,
+            @Valid @RequestBody CreateReportRequestDto requestDto) {
+        Long userId = (Long) request.getAttribute("userId");
+        CreateReportDto reportDto = CreateReportDto.builder()
+                .requestedUserId(userId)
+                .content(requestDto.getContent())
+                .reservationId(requestDto.getReservationId())
+                .build();
+
+        reportService.createReport(reportDto);
+
+        return Response.of(HttpStatus.OK);
+    }
+}

--- a/server/src/main/java/com/hexacore/tayo/report/ReportRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/report/ReportRepository.java
@@ -1,0 +1,10 @@
+package com.hexacore.tayo.report;
+
+import com.hexacore.tayo.report.model.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+}

--- a/server/src/main/java/com/hexacore/tayo/report/ReportService.java
+++ b/server/src/main/java/com/hexacore/tayo/report/ReportService.java
@@ -1,0 +1,43 @@
+package com.hexacore.tayo.report;
+
+import com.hexacore.tayo.common.errors.ErrorCode;
+import com.hexacore.tayo.common.errors.GeneralException;
+import com.hexacore.tayo.report.dto.CreateReportDto;
+import com.hexacore.tayo.report.model.Report;
+import com.hexacore.tayo.reservation.ReservationRepository;
+import com.hexacore.tayo.reservation.model.Reservation;
+import com.hexacore.tayo.reservation.model.ReservationStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final ReservationRepository reservationRepository;
+
+    public void createReport(CreateReportDto reportDto) {
+        Reservation reservation = reservationRepository.findById(reportDto.getReservationId())
+                .orElseThrow(() -> new GeneralException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        Long requestedUserId = reportDto.getRequestedUserId();
+
+        // 신고한 사용자가 예약의 호스트가 아닌 경우
+        if (!requestedUserId.equals(reservation.getHost().getId())) {
+            throw new GeneralException(ErrorCode.REPORTED_BY_OTHERS);
+        }
+
+        // Using 상태가 아닌 예약에 신고를 하는 경우
+        if (reservation.getStatus() != ReservationStatus.USING) {
+            throw new GeneralException(ErrorCode.REPORTED_NOT_USING_RESERVATION);
+        }
+
+        Report report = Report.builder()
+                .reservation(reservation)
+                .content(reportDto.getContent())
+                .build();
+
+        reportRepository.save(report);
+    }
+}

--- a/server/src/main/java/com/hexacore/tayo/report/ReportService.java
+++ b/server/src/main/java/com/hexacore/tayo/report/ReportService.java
@@ -33,6 +33,11 @@ public class ReportService {
             throw new GeneralException(ErrorCode.REPORTED_NOT_USING_RESERVATION);
         }
 
+        // 이미 신고된 예약에 신고를 하는 경우
+        if (reservation.getReport() != null) {
+            throw new GeneralException(ErrorCode.ALREADY_REPORTED);
+        }
+
         Report report = Report.builder()
                 .reservation(reservation)
                 .content(reportDto.getContent())

--- a/server/src/main/java/com/hexacore/tayo/report/dto/CreateReportDto.java
+++ b/server/src/main/java/com/hexacore/tayo/report/dto/CreateReportDto.java
@@ -1,0 +1,13 @@
+package com.hexacore.tayo.report.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CreateReportDto {
+
+    Long requestedUserId;
+    Long reservationId;
+    String content;
+}

--- a/server/src/main/java/com/hexacore/tayo/report/dto/CreateReportRequestDto.java
+++ b/server/src/main/java/com/hexacore/tayo/report/dto/CreateReportRequestDto.java
@@ -1,0 +1,15 @@
+package com.hexacore.tayo.report.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CreateReportRequestDto {
+
+    @NotNull
+    Long reservationId;
+    @NotNull
+    String content;
+}

--- a/server/src/main/java/com/hexacore/tayo/report/model/Report.java
+++ b/server/src/main/java/com/hexacore/tayo/report/model/Report.java
@@ -1,0 +1,40 @@
+package com.hexacore.tayo.report.model;
+
+import com.hexacore.tayo.reservation.model.Reservation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "report")
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    @Column(name = "content", nullable = false)
+    @Setter
+    private String content;
+
+    @Builder
+    public Report(Reservation reservation, String content) {
+        this.reservation = reservation;
+        this.content = content;
+    }
+}

--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationRepository.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    Page<Reservation> findAllByHost_id(Long hostId, Pageable pageable);
+    Page<Reservation> findAllByHost_idOrderByStatusAscRentDateTimeAsc(Long hostId, Pageable pageable);
 
-    Page<Reservation> findAllByGuest_id(Long guestId, Pageable pageable);
+    Page<Reservation> findAllByGuest_idOrderByStatusAscRentDateTimeAsc(Long guestId, Pageable pageable);
 
     List<Reservation> findAllByCar_idAndStatusInOrderByRentDateTimeAsc(Long carId, List<ReservationStatus> statusList);
 }

--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
@@ -14,22 +14,19 @@ import com.hexacore.tayo.reservation.model.ReservationStatus;
 import com.hexacore.tayo.user.UserRepository;
 import com.hexacore.tayo.user.model.User;
 import jakarta.transaction.Transactional;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -90,7 +87,8 @@ public class ReservationService {
 
     @Transactional
     public Page<Reservation> getGuestReservations(Long guestUserId, Pageable pageable) {
-        Page<Reservation> reservations = reservationRepository.findAllByGuest_id(guestUserId, pageable);
+        Page<Reservation> reservations =
+                reservationRepository.findAllByGuest_idOrderByStatusAscRentDateTimeAsc(guestUserId, pageable);
         updateReservationStatusByCurrentDateTime(reservations);
 
         return reservations;
@@ -98,7 +96,8 @@ public class ReservationService {
 
     @Transactional
     public Page<Reservation> getHostReservations(Long hostUserId, Pageable pageable) {
-        Page<Reservation> reservations = reservationRepository.findAllByHost_id(hostUserId, pageable);
+        Page<Reservation> reservations =
+                reservationRepository.findAllByHost_idOrderByStatusAscRentDateTimeAsc(hostUserId, pageable);
         updateReservationStatusByCurrentDateTime(reservations);
 
         return reservations;

--- a/server/src/main/java/com/hexacore/tayo/reservation/model/Reservation.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/model/Reservation.java
@@ -2,6 +2,7 @@ package com.hexacore.tayo.reservation.model;
 
 import com.hexacore.tayo.car.model.Car;
 import com.hexacore.tayo.common.BaseTime;
+import com.hexacore.tayo.report.model.Report;
 import com.hexacore.tayo.user.model.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -41,6 +43,9 @@ public class Reservation extends BaseTime {
     @ManyToOne
     @JoinColumn(name = "car_id", nullable = false)
     private Car car;
+
+    @OneToOne(mappedBy = "reservation")
+    private Report report;
 
     @Column(name = "rent_date_time", nullable = false)
     private LocalDateTime rentDateTime;

--- a/server/src/main/java/com/hexacore/tayo/reservation/model/ReservationStatus.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/model/ReservationStatus.java
@@ -4,9 +4,9 @@ import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
 
 public enum ReservationStatus {
-    CANCEL("cancel"),
-    READY("ready"),
     USING("using"),
+    READY("ready"),
+    CANCEL("cancel"),
     TERMINATED("terminated");
 
     private final String status;


### PR DESCRIPTION
close #207 
## DONE

- [x] 신고하기 백엔드 API 추가 
- [x] 예약 정렬 기준 추가
- [ ] 신고하기 FE 추가 - 버튼 눌렀을 때 모달로 뜰지 페이지로 뜰지 고민
- [ ] 추가사항: FE 차량등록/수정에서 차량명(ex. 아반떼 MD)이 없을 시 처리


## 리뷰 포인트

- 현재 완료한 사항
  - 신고하기 백엔드 API를 추가했습니다.
    - 일단 신고 생성만 만들고 추후에 기능을 추가할 생각입니다.
    - 예약과 OneToOne관계이고 예약이 주 엔티티입니다.
  - 예약 정렬 기준을 변경하고 Status ENUM의 위치를 변경했습니다.
    - Using, Ready, Cancel, Terminated 순으로 정렬하고 2차로 대여시간이 빠른 순으로 정렬합니다.
- 진행 중인 사항
  - 신고하기 FE 추가 
  - FE에서 차량 등록할때 차량명이 없을 시 예외 동작 추가
