### PR TITLE
[BE] #225: 예약 관련 사항 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     RESERVATION_ALREADY_READY_OR_USING(HttpStatus.BAD_REQUEST, "해당 예약일시 구간에 이미 예약대기 혹은 사용중인 예약이 있습니다."),
     RESERVATION_STATUS_CHANGED_BY_OTHERS(HttpStatus.BAD_REQUEST, "해당 예약과 관련된 호스트/게스트만 예약상태를 변경할 수 있습니다."),
     RESERVATION_STATUS_INVALID_CHANGE(HttpStatus.BAD_REQUEST, "요청하신 예약상태로 변경할 수 없습니다."),
+    RESERVATION_CANCEL_TOO_LATE(HttpStatus.BAD_REQUEST, "해당 예약의 시작 시간의 24시간 이전에 예약을 취소할 수 있습니다."),
     RESERVATION_STATUS_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당하는 예약상태는 존재하지 않습니다."),
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 타입입니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),

--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationRepository.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    Page<Reservation> findAllByHost_id(Long hostId, Pageable pageable);
+    Page<Reservation> findAllByHost_idOrderByStatusAscRentDateTimeAsc(Long hostId, Pageable pageable);
 
-    Page<Reservation> findAllByGuest_id(Long guestId, Pageable pageable);
+    Page<Reservation> findAllByGuest_idOrderByStatusAscRentDateTimeAsc(Long guestId, Pageable pageable);
 
     List<Reservation> findAllByCar_idAndStatusInOrderByRentDateTimeAsc(Long carId, List<ReservationStatus> statusList);
 }

--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    Page<Reservation> findAllByHost_idOrderByStatusAscRentDateTimeAsc(Long hostId, Pageable pageable);
+    List<Reservation> findAllByHost_idOrderByStatusAscRentDateTimeAsc(Long hostId);
 
     Page<Reservation> findAllByGuest_idOrderByStatusAscRentDateTimeAsc(Long guestId, Pageable pageable);
 

--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
@@ -134,9 +134,11 @@ public class ReservationService {
             else if (originStatus == ReservationStatus.USING && requestedStatus == ReservationStatus.TERMINATED) {
                 reservation.setStatus(requestedStatus);
                 Integer feePerHour = reservation.getCar().getFeePerHour();
+                // 0~59분도 1시간 추가 요금으로 책정.
                 // 연체할 경우 시간당 추가 과금 (returnDateTime <= currentDateTime)
                 if (!returnDateTime.isAfter(currentDateTime)) {
-                    reservation.setExtraFee(feePerHour * (int) returnDateTime.until(currentDateTime, ChronoUnit.HOURS));
+                    int delayedHours = (int) returnDateTime.until(currentDateTime, ChronoUnit.HOURS);
+                    reservation.setExtraFee(feePerHour * (delayedHours + 1));
                 }
             } else {
                 invalidUpdate = true;

--- a/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/ReservationService.java
@@ -35,7 +35,8 @@ public class ReservationService {
     private final PaymentManager paymentManager;
 
     @Transactional
-    public CreateReservationResponseDto createReservation(CreateReservationRequestDto createReservationRequestDto, Long guestUserId) {
+    public CreateReservationResponseDto createReservation(CreateReservationRequestDto createReservationRequestDto,
+            Long guestUserId) {
         User guestUser = userRepository.findByIdAndIsDeletedFalse(guestUserId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
@@ -74,7 +75,9 @@ public class ReservationService {
 
     @Transactional
     public Page<Reservation> getGuestReservations(Long guestUserId, Pageable pageable) {
-        Page<Reservation> reservations = reservationRepository.findAllByGuest_id(guestUserId, pageable);
+        // Using, Ready, Cancel, Terminated 순으로 정렬하여 Page로 응답한다.
+        Page<Reservation> reservations =
+                reservationRepository.findAllByGuest_idOrderByStatusAscRentDateTimeAsc(guestUserId, pageable);
         updateReservationStatusByCurrentDateTime(reservations);
 
         return reservations;
@@ -82,7 +85,9 @@ public class ReservationService {
 
     @Transactional
     public Page<Reservation> getHostReservations(Long hostUserId, Pageable pageable) {
-        Page<Reservation> reservations = reservationRepository.findAllByHost_id(hostUserId, pageable);
+        // Using, Ready, Cancel, Terminated 순으로 정렬하여 Page로 응답한다.
+        Page<Reservation> reservations =
+                reservationRepository.findAllByHost_idOrderByStatusAscRentDateTimeAsc(hostUserId, pageable);
         updateReservationStatusByCurrentDateTime(reservations);
 
         return reservations;
@@ -218,7 +223,8 @@ public class ReservationService {
         }
 
         // 결제 요청
-        TossPaymentResponse response = paymentManager.confirmBilling(amount, orderName, customerName, user.getCustomerKey(), user.getBillingKey());
+        TossPaymentResponse response = paymentManager.confirmBilling(amount, orderName, customerName,
+                user.getCustomerKey(), user.getBillingKey());
 
         // 예약 테이블의 paymentKey 업데이트
         Reservation reservation = reservationRepository.findById(reservationId)

--- a/server/src/main/java/com/hexacore/tayo/reservation/model/ReservationStatus.java
+++ b/server/src/main/java/com/hexacore/tayo/reservation/model/ReservationStatus.java
@@ -4,9 +4,9 @@ import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
 
 public enum ReservationStatus {
-    CANCEL("cancel"),
-    READY("ready"),
     USING("using"),
+    READY("ready"),
+    CANCEL("cancel"),
     TERMINATED("terminated");
 
     private final String status;


### PR DESCRIPTION
close #225

## DONE
- [x] 예약이 완료된 경우(`Using -> Terminated`) 추가 요금 계산 변경 (0~59분 -> 1시간 추가요금)
- [x] 예약 조회시 1차로는 `Using->Ready->Cancel->Terminated`순으로, 2차로는 대여시간 순으로 정렬
- [x] 호스트 예약 조회는 페이지네이션을 쓰지않고 전체 내역을 조회하도록 변경
- [x] 추가사항: 예약 상태 변경 로직 수정

## 리뷰 포인트

- 추가 요금이 1시간 이전에는 0원으로 된 점을 수정 -> 초과할때부터 추가요금
- 예약 조회시 Repository 에서 정렬해서 조회 결과 응답 (페이지네이션 때문에 Repository에서)
- 호스트 예약 조회는 페이지네이션을 쓰지 못해서 변경
  - 왜냐하면 예약 가능 일자에 "모든" 예약된 일시를 판단하여 FE에서 보여줘야하기 때문에
- 예약 조회시 1차로는 `Using->Ready->Cancel->Terminated`순으로, 2차로는 대여시간 순으로 정렬
  - ReservationStatus enum의 순서를 변경했기 때문에 현재 데이터가 변경될 수 있음
- 추가사항: 예약 상태가 동일 날짜일 때가 아니라 rentDateTime <= currentDateTime 이면 `Ready->Using` 상태로 변경
  - updateReservationStatus에서 대여 시작 로직 삭제
  - 또한 예약 시작 시간 24시간 이전만 취소 가능하고 이후에는 RESERVATION_CANCEL_TOO_LATE 예외처리하도록 변경