### PR TITLE
[FE] #234: 사용자 구독 요청 기본 timeOut 설정 변경

### DIFF
--- a/client/src/components/notification/NotificationBox.tsx
+++ b/client/src/components/notification/NotificationBox.tsx
@@ -60,6 +60,7 @@ export default function NotificationBox() {
         headers: {
           Authorization: 'Bearer ' + auth.accessToken
         },
+        heartbeatTimeout: 1000 * 60 * 60
       });
 
       eventSource.addEventListener('message', (event) => {

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Link, redirect, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import InputBox from '@/components/InputBox';
 import Button from '@/components/Button';
 import type { ResponseWithData } from '@/fetches/common/response.type';


### PR DESCRIPTION
- close #234 
## DONE
- [x] 클라이언트에서 사용자 구독 요청 기본 timeOut 설정 45초 -> 1시간으로 변경

## 설명
현재 SSE를 위해 클라리언트에서 처음에 구독 요청을 보내고 있습니다.

하지만 이벤트를 수신할 eventSource가 기본적으로 45초동안 아무 이벤트가 수신되지 않으면 다시 연결을 요청합니다.
45초는 너무 짧다고 판단되며 현재 서버에서는 이벤트를 보내는 SseEmitter 객체를 생성할 때 기본 타임아웃을 1시간으로 설정하고 있기 때문에
이에 맞춰서 클라이언트의 타임아웃도 1시간으로 변경합니다.
