### PR TITLE
[BE] #224: 차량 등록, 삭제, 카테고리 조회, 결제 관련 API 리팩토링 및 테스트 코드 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -11,7 +11,9 @@ import com.hexacore.tayo.car.model.Car;
 import com.hexacore.tayo.car.model.CarImage;
 import com.hexacore.tayo.car.model.CarType;
 import com.hexacore.tayo.car.model.FuelType;
+import com.hexacore.tayo.category.CategoryRepository;
 import com.hexacore.tayo.category.SubcategoryRepository;
+import com.hexacore.tayo.category.model.Category;
 import com.hexacore.tayo.category.model.Subcategory;
 import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
@@ -43,6 +45,7 @@ public class CarService {
     private final CarImageRepository carImageRepository;
     private final CarDateRangeRepository carDateRangeRepository;
     private final SubcategoryRepository subcategoryRepository;
+    private final CategoryRepository categoryRepository;
     private final ReservationRepository reservationRepository;
     private final S3Manager s3Manager;
 
@@ -64,8 +67,8 @@ public class CarService {
 
         // 등록에 필요한 정보 가져오기
         Subcategory subcategory = subcategoryRepository.findByName(createCarRequestDto.getCarName())
-                // 존재하지 않는 모델인 경우
-                .orElseThrow(() -> new GeneralException(ErrorCode.CAR_MODEL_NOT_FOUND));
+                // 존재하지 않는 모델인 경우 새로운 row 추가
+                .orElseGet(() -> createSubcategory(createCarRequestDto.getCarName()));
 
         Car car = carRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(userId, createCarRequestDto.getCarNumber())
                 .orElse(null);
@@ -106,6 +109,21 @@ public class CarService {
             // 이미지 저장
             saveImages(createCarRequestDto.getImageIndexes(), createCarRequestDto.getImageFiles(), carEntity);
         }
+    }
+
+    /* 서브 카테고리 추가 */
+    public Subcategory createSubcategory(String subcategoryName) {
+        List<Category> categories = categoryRepository.findAll();
+
+        Category category = categories.stream()
+                .filter(c -> subcategoryName.contains(c.getName()))
+                .findFirst()
+                // 해당하는 카테고리가 없는 경우 ETC 카테고리로 등록
+                .orElseGet(() -> categories.stream()
+                        .filter(c -> "ETC".equals(c.getName()))
+                        .findFirst().orElseThrow(() -> new GeneralException(ErrorCode.ETC_MODEL_NOT_FOUND)));
+
+        return subcategoryRepository.save(Subcategory.builder().name(subcategoryName).category(category).build());
     }
 
     public Slice<SearchCarsResultDto> searchCars(SearchCarsDto searchCarsDto, Pageable pageable) {
@@ -227,7 +245,8 @@ public class CarService {
     }
 
     /* 이미지 엔티티 저장 */
-    private void saveImages(List<Integer> indexes, List<MultipartFile> files, Car car) {
+    @Transactional
+    public void saveImages(List<Integer> indexes, List<MultipartFile> files, Car car) {
         if (indexes == null || files == null) {
             return;
         }

--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -112,6 +112,7 @@ public class CarService {
     }
 
     /* 서브 카테고리 추가 */
+    @Transactional
     public Subcategory createSubcategory(String subcategoryName) {
         List<Category> categories = categoryRepository.findAll();
 

--- a/server/src/main/java/com/hexacore/tayo/category/CategoryCustomRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/category/CategoryCustomRepository.java
@@ -1,0 +1,9 @@
+package com.hexacore.tayo.category;
+
+import com.hexacore.tayo.category.model.Category;
+import java.util.List;
+
+public interface CategoryCustomRepository {
+
+    List<Category> findAllFetch();
+}

--- a/server/src/main/java/com/hexacore/tayo/category/CategoryCustomRepositoryImpl.java
+++ b/server/src/main/java/com/hexacore/tayo/category/CategoryCustomRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.hexacore.tayo.category;
+
+import com.hexacore.tayo.category.model.Category;
+import com.hexacore.tayo.category.model.QCategory;
+import com.hexacore.tayo.category.model.QSubcategory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CategoryCustomRepositoryImpl implements CategoryCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<Category> findAllFetch() {
+        QCategory category = QCategory.category;
+        QSubcategory subcategory = QSubcategory.subcategory;
+
+        return queryFactory
+                .selectFrom(category)
+                .leftJoin(category.subcategories, subcategory)
+                .fetchJoin()
+                .fetch();
+    }
+}

--- a/server/src/main/java/com/hexacore/tayo/category/CategoryRepository.java
+++ b/server/src/main/java/com/hexacore/tayo/category/CategoryRepository.java
@@ -1,20 +1,12 @@
 package com.hexacore.tayo.category;
 
 import com.hexacore.tayo.category.model.Category;
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryCustomRepository {
 
     Optional<Category> findByName(String name);
-
-    @EntityGraph(attributePaths = {"subcategories"}, type = EntityGraphType.FETCH)
-    @Query("select c from Category c left join fetch c.subcategories")
-    List<Category> findAllFetch();
 }

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -24,7 +24,6 @@ public enum ErrorCode {
     USER_CAR_NOT_EXISTS(HttpStatus.NOT_FOUND, "등록한 차량이 존재하지 않습니다."),
     CAR_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 차량입니다."),
     CAR_IMAGE_INSUFFICIENT(HttpStatus.BAD_REQUEST, "이미지를 5개 이상 등록해야 합니다."),
-    CAR_MODEL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 모델명입니다."),
     ETC_MODEL_NOT_FOUND(HttpStatus.BAD_REQUEST, "DB에 ETC 모델 데이터가 존재하지 않습니다."),
     CAR_NUMBER_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 차량 번호입니다."),
     CAR_UPDATED_BY_OTHERS(HttpStatus.BAD_REQUEST, "해당 차량을 소유한 사용자만 차량 정보를 변경할 수 있습니다."),

--- a/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
+++ b/server/src/main/java/com/hexacore/tayo/common/errors/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     CAR_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 차량입니다."),
     CAR_IMAGE_INSUFFICIENT(HttpStatus.BAD_REQUEST, "이미지를 5개 이상 등록해야 합니다."),
     CAR_MODEL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 모델명입니다."),
+    ETC_MODEL_NOT_FOUND(HttpStatus.BAD_REQUEST, "DB에 ETC 모델 데이터가 존재하지 않습니다."),
     CAR_NUMBER_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 차량 번호입니다."),
     CAR_UPDATED_BY_OTHERS(HttpStatus.BAD_REQUEST, "해당 차량을 소유한 사용자만 차량 정보를 변경할 수 있습니다."),
     INVALID_CAR_DATE_RANGE_DUPLICATED(HttpStatus.BAD_REQUEST, "예약 가능일자에 겹치는 부분이 있습니다."),

--- a/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
+++ b/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
+import java.sql.Timestamp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -29,20 +30,20 @@ public class S3Manager {
             // Content-Type이 이미지 파일이 아닌 경우
             throw new GeneralException(ErrorCode.INVALID_IMAGE_TYPE);
         }
-        String originalFilename = image.getOriginalFilename();
+        String fileName = image.getOriginalFilename() + new Timestamp(System.currentTimeMillis());
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(image.getSize());
         metadata.setContentType(image.getContentType());
 
         try {
             amazonS3Client.putObject(
-                    new PutObjectRequest(bucket, originalFilename, image.getInputStream(), metadata)
+                    new PutObjectRequest(bucket, fileName, image.getInputStream(), metadata)
             );
         } catch (IOException e) {
             throw new GeneralException(ErrorCode.S3_UPLOAD_FAILED);
         }
 
-        return amazonS3Client.getUrl(bucket, originalFilename).toString();
+        return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
     /* 이미지 파일을 S3에서 삭제 */

--- a/server/src/test/java/com/hexacore/tayo/TestConfig.java
+++ b/server/src/test/java/com/hexacore/tayo/TestConfig.java
@@ -1,0 +1,19 @@
+package com.hexacore.tayo;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/server/src/test/java/com/hexacore/tayo/car/CarRepositoryTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.hexacore.tayo.car;
 
+import com.hexacore.tayo.TestConfig;
 import com.hexacore.tayo.car.model.Car;
 import com.hexacore.tayo.car.model.CarType;
 import com.hexacore.tayo.category.CategoryRepository;
@@ -18,8 +19,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(TestConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class CarRepositoryTest {
 
@@ -38,7 +41,7 @@ public class CarRepositoryTest {
     @BeforeEach
     void createUserAndModel() {
         User user = userRepository.save(
-                User.builder().email("test@test.com").name("테스트").phoneNumber("010-0000-0000")
+                User.builder().email("test_code@test.com").name("테스트").phoneNumber("010-0000-0000")
                         .password("1234")
                         .build());
         Category category = categoryRepository.save(
@@ -53,7 +56,7 @@ public class CarRepositoryTest {
     @DisplayName("ownerId와 carNumber로 검색해서 isDelete = true인 CarEntity를 반환한다")
     void findByOwner_IdAndCarNumberAndIsDeletedTrue() {
         // given
-        String carNumber = "11주 1111";
+        String carNumber = "00주 0000";
         carRepository.save(
                 Car.builder().owner(user).subcategory(subcategory).carNumber(carNumber).type(CarType.LIGHT).capacity(2)
                         .address("경기도 테스트 주소")
@@ -81,19 +84,19 @@ public class CarRepositoryTest {
                         .isDeleted(false).build());
 
         // when
-        List<Car> cars = carRepository.findByOwner_IdAndIsDeletedFalse(user.getId());
+       Optional<Car> car = carRepository.findByOwner_IdAndIsDeletedFalse(user.getId());
 
         // then
-        Assertions.assertThat(cars.size()).isEqualTo(1);
-        Assertions.assertThat(cars.get(0).getOwner().getId()).isEqualTo(user.getId());
-        Assertions.assertThat(cars.get(0).getIsDeleted()).isFalse();
+        Assertions.assertThat(car).isPresent();
+        Assertions.assertThat(car.get().getOwner().getId()).isEqualTo(user.getId());
+        Assertions.assertThat(car.get().getIsDeleted()).isFalse();
     }
 
     @Test
     @DisplayName("carNumber로 검색해서 isDeleted = false인 CarEntity 리스트를 반환한다")
     void findByCarNumberAndIsDeletedFalse() {
         // given
-        String carNumber = "11주 1111";
+        String carNumber = "00주 0000";
         carRepository.save(
                 Car.builder().owner(user).subcategory(subcategory).carNumber(carNumber).type(CarType.LIGHT).capacity(2)
                         .address("경기도 테스트 주소")

--- a/server/src/test/java/com/hexacore/tayo/category/CategoryRepositoryTest.java
+++ b/server/src/test/java/com/hexacore/tayo/category/CategoryRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.hexacore.tayo.category;
+
+import com.hexacore.tayo.TestConfig;
+import com.hexacore.tayo.category.model.Category;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    public void testFindAllFetch() {
+        // when
+        List<Category> categories = categoryRepository.findAllFetch();
+
+        // then
+        Assertions.assertThat(categories).isNotNull();
+        Assertions.assertThat(categories).hasSizeGreaterThan(0); // 데이터가 적어도 하나 이상 존재한다고 가정
+        for (Category category : categories) {
+            Assertions.assertThat(category.getSubcategories()).isNotNull(); // 각 Category에 대해 Subcategories가 로드되었는지 확인
+        }
+    }
+}

--- a/server/src/test/java/com/hexacore/tayo/category/CategoryServiceTest.java
+++ b/server/src/test/java/com/hexacore/tayo/category/CategoryServiceTest.java
@@ -24,7 +24,7 @@ public class CategoryServiceTest {
     @DisplayName("getCategories(): Model 테이블에 존재하는 모든 모델, 세부모델명을 조회한다.")
     void getCategoriesTest() {
         // given
-        BDDMockito.given(categoryRepository.findAll())
+        BDDMockito.given(categoryRepository.findAllFetch())
                 .willReturn(List.of(Category.builder().name("모델명")
                         .subcategories(List.of(Subcategory.builder().name("모델명 세부모델명").build())).build()));
         // when


### PR DESCRIPTION
## DONE

- [x] 차량 이미지 등록시 timestamp 추가
- [x] 차량 등록 API 수정: 서브 카테고리가 일치하지 않은 경우 새로운 데이터 추가 - 카테고리는 포함되는 게 있으면 해당 카테고리 연결, 없으면 ETC 카테고리 연결
- [x] QueryDSL 적용 -> GET /categories 에만 적용
- [x] 테스트 코드 수정