### PR TITLE
[BE] HOTFIX: S3 Manager 파일 명에서 유효하지 않은 확장자명이 들어가는 버그 수정

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
+++ b/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
@@ -30,7 +30,7 @@ public class S3Manager {
             // Content-Type이 이미지 파일이 아닌 경우
             throw new GeneralException(ErrorCode.INVALID_IMAGE_TYPE);
         }
-        String fileName = image.getOriginalFilename() + new Timestamp(System.currentTimeMillis());
+        String fileName = new Timestamp(System.currentTimeMillis()) + image.getOriginalFilename();
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(image.getSize());
         metadata.setContentType(image.getContentType());


### PR DESCRIPTION
## DONE

- [x] S3Manager에서 이미지를 S3에 업로드할 때 파일 확장자가 제대로 들어가지 않는 버그 수정
## 리뷰 포인트

- before: 이미지 파일명 뒤에 타임스탬프를 추가해서 확장자가 달라지는 경우 발생
- after: 타임스탬프를 이미지 파일명 앞에 추가하는 걸로 수정