### PR TITLE
[FE] #256: 차량 등록/수정 페이지에서 서버 연결이 안될 경우에도 렌더링되도록 수정

### DIFF
--- a/client/src/pages/hosts/HostRegister.tsx
+++ b/client/src/pages/hosts/HostRegister.tsx
@@ -88,10 +88,10 @@ function HostRegister() {
   useEffect(() => {
     setCarDetail(null);
     setCarNumberConfirmed(false);
-    // 서버에서 받을 수 있는 정보가 없을 때
-    if (userCarInfo === null) return;
 
-    if (userCarInfo.isUpdate && userCarInfo.carDetail) {
+    // 서버에서 받을 수 있는 정보가 없을 때는 (userCarInfo === null)
+    // 실행하지 않는다.
+    if (userCarInfo && userCarInfo.isUpdate && userCarInfo.carDetail) {
       const carDetail = userCarInfo.carDetail;
       setAddress(carDetail.address);
       setDescription(carDetail.description);
@@ -129,11 +129,8 @@ function HostRegister() {
   }, [address]);
 
   // 서버에 접근할 수 없거나 요청에 대한 응답에 오류가 발생할 경우
+  // 로그인한 상태가 아닌 경우도 포함
   if (userCarInfo === null) {
-    return <div>{'서버에 연결할 수 없습니다. 다시 시도해 주세요.'}</div>;
-  }
-  // 인증이 안된 경우 빈 페이지를 보여준다. -> 로그인 페이지로 리다이렉트
-  if (userCarInfo.errMessage === '로그인이 필요한 요청입니다.') {
     return <div></div>;
   }
 

--- a/client/src/pages/hosts/HostRegister.tsx
+++ b/client/src/pages/hosts/HostRegister.tsx
@@ -88,6 +88,8 @@ function HostRegister() {
   useEffect(() => {
     setCarDetail(null);
     setCarNumberConfirmed(false);
+    // 서버에서 받을 수 있는 정보가 없을 때
+    if (userCarInfo === null) return;
 
     if (userCarInfo.isUpdate && userCarInfo.carDetail) {
       const carDetail = userCarInfo.carDetail;
@@ -202,7 +204,6 @@ function HostRegister() {
         { headers: { Authorization: `Token ${import.meta.env.VITE_CAR_INFO_API_TOKEN}` } },
       )
       .finally(() => setLoadingCarNumber(false));
-
 
     const resultMessage = response.data.result;
     const responseData: CarDetailResponseByApi = response.data.data;

--- a/client/src/pages/hosts/hostsRoutes.tsx
+++ b/client/src/pages/hosts/hostsRoutes.tsx
@@ -15,7 +15,6 @@ export type HostRegisterLoaderData = {
   username: string;
   isUpdate: boolean;
   carDetail: CarDetailJsonData | undefined;
-  errMessage: string | null;
 };
 
 const hostsRoutes: RouteObject[] = [
@@ -55,12 +54,7 @@ const hostsRoutes: RouteObject[] = [
       if (userResponse.status !== 'fulfilled' || carResponse.status !== 'fulfilled') return null;
       if (userResponse.status === 'fulfilled') {
         if (userResponse.value === undefined) {
-          return {
-            username: null,
-            isUpdate: null,
-            carDetail: null,
-            errMessage: '로그인이 필요한 요청입니다.',
-          };
+          return null;
         }
       }
 
@@ -70,7 +64,6 @@ const hostsRoutes: RouteObject[] = [
         username: userResponse.value.data.name,
         isUpdate: isUpdate,
         carDetail: carResponse.value.data,
-        errMessage: null,
       };
       return data;
     },

--- a/client/src/pages/hosts/hostsRoutes.tsx
+++ b/client/src/pages/hosts/hostsRoutes.tsx
@@ -23,9 +23,9 @@ const hostsRoutes: RouteObject[] = [
     path: 'hosts/manage',
     loader: async () => {
       const [carDetailResult, HostReservationResult] = await Promise.allSettled([fetchCarDetail(), fetchHostReservations()]);
-      const data : HostManageLoaderData = {
+      const data: HostManageLoaderData = {
         carDetail: undefined,
-        reservations: []
+        reservations: [],
       };
       if (carDetailResult.status == 'fulfilled' && carDetailResult != undefined) {
         if (carDetailResult.value.code === 200) {
@@ -50,21 +50,24 @@ const hostsRoutes: RouteObject[] = [
     element: <HostRegister />,
     loader: async () => {
       // fetchUser(NaN)이면 로그인한 사용자의 정보를 받아온다.
-      const [response, carResponse] = await Promise.allSettled([fetchUser(NaN), fetchCarDetail()]);
+      const [userResponse, carResponse] = await Promise.allSettled([fetchUser(NaN), fetchCarDetail()]);
 
-      if (response.status !== 'fulfilled' || carResponse.status !== 'fulfilled') return null;
-      if (response.status === 'fulfilled' && response.value === undefined) {
-        return {
-          username: null,
-          isUpdate: null,
-          carDetail: null,
-          errMessage: '로그인이 필요한 요청입니다.',
-        };
+      if (userResponse.status !== 'fulfilled' || carResponse.status !== 'fulfilled') return null;
+      if (userResponse.status === 'fulfilled') {
+        if (userResponse.value === undefined) {
+          return {
+            username: null,
+            isUpdate: null,
+            carDetail: null,
+            errMessage: '로그인이 필요한 요청입니다.',
+          };
+        }
       }
+
       const isUpdate: boolean = carResponse.value.success;
 
       const data: HostRegisterLoaderData = {
-        username: response.value.data.name,
+        username: userResponse.value.data.name,
         isUpdate: isUpdate,
         carDetail: carResponse.value.data,
         errMessage: null,


### PR DESCRIPTION
close #256 
## DONE

- [x] 차량 등록/수정 페이지에서 서버 연결이 안될 경우 렌더링 되도록 수정

## 리뷰 포인트

- 차량 등록/수정 페이지에서 서버 연결이 안될 경우 렌더링되도록 수정 
  - "서버에 연결할 수 없습니다. 다시 시도해 주세요." 메시지만 나오는 화면을 보이도록 변경
  - useEffect Hook에서 서버에 연결을 실패하거나 API 요청 상태가 'rejected'일 경우의 예외 처리

## 스크린 샷

<img width="1458" alt="스크린샷 2024-02-23 오후 6 29 16" src="https://github.com/softeerbootcamp-3rd/Team9-HexaCore/assets/148764580/1ee9975c-e925-4e9c-9738-d5a56c52328c">