### PR TITLE
[BE] #259: Pre-signed URL 적용

### DIFF
--- a/server/src/main/java/com/hexacore/tayo/car/CarController.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarController.java
@@ -2,6 +2,8 @@ package com.hexacore.tayo.car;
 
 import com.hexacore.tayo.car.dto.CreateCarRequestDto;
 import com.hexacore.tayo.car.dto.GetCarResponseDto;
+import com.hexacore.tayo.car.dto.GetPresignedUrlsRequestDto;
+import com.hexacore.tayo.car.dto.GetPresignedUrlsResposneDto;
 import com.hexacore.tayo.car.dto.SearchCarsDto;
 import com.hexacore.tayo.car.dto.SearchCarsRequestDto;
 import com.hexacore.tayo.car.dto.SearchCarsResultDto;
@@ -44,12 +46,20 @@ public class CarController {
 
     @PostMapping
     public ResponseEntity<Response> createCar(HttpServletRequest request,
-            @Valid @ModelAttribute CreateCarRequestDto createCarRequestDto) {
+            @Valid @RequestBody CreateCarRequestDto createCarRequestDto) {
         Long userId = (Long) request.getAttribute("userId");
         carService.createCar(createCarRequestDto, userId);
 
         return Response.of(HttpStatus.CREATED);
     }
+
+    @GetMapping("/presigned-urls")
+    public ResponseEntity<Response> getPresignedUrls(@Valid @ModelAttribute GetPresignedUrlsRequestDto getPresignedUrlsRequestDto) {
+        GetPresignedUrlsResposneDto getPresignedUrlsResposneDto = carService.generatePresignedUrl(getPresignedUrlsRequestDto);
+        return Response.of(HttpStatus.OK, getPresignedUrlsResposneDto);
+    }
+
+
 
     @DeleteMapping("/{carId}")
     public ResponseEntity<Response> deleteCar(HttpServletRequest request, @PathVariable Long carId) {
@@ -66,7 +76,7 @@ public class CarController {
 
     @PutMapping("{carId}")
     public ResponseEntity<Response> updateCar(@PathVariable Long carId,
-            @Valid @ModelAttribute UpdateCarRequestDto updateCarRequestDto, HttpServletRequest request) {
+            @Valid @RequestBody UpdateCarRequestDto updateCarRequestDto, HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
         carService.updateCar(carId, updateCarRequestDto, userId);
         return Response.of(HttpStatus.OK);

--- a/server/src/main/java/com/hexacore/tayo/car/CarService.java
+++ b/server/src/main/java/com/hexacore/tayo/car/CarService.java
@@ -269,6 +269,7 @@ public class CarService {
         }
     }
 
+    @Transactional
     public void saveImages(List<Integer> indexes, List<String> imageUrls, Car car) {
         if (imageUrls == null || indexes == null) {
             return;

--- a/server/src/main/java/com/hexacore/tayo/car/dto/CreateCarRequestDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/CreateCarRequestDto.java
@@ -32,8 +32,10 @@ public class CreateCarRequestDto {
     @NotNull
     private Position position;
     private String description;
+//    @NotNull
+//    private List<MultipartFile> imageFiles;
     @NotNull
-    private List<MultipartFile> imageFiles;
+    private List<String> imageUrls;
     @NotNull
     private List<Integer> imageIndexes;
 

--- a/server/src/main/java/com/hexacore/tayo/car/dto/CreateCarRequestDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/CreateCarRequestDto.java
@@ -32,8 +32,6 @@ public class CreateCarRequestDto {
     @NotNull
     private Position position;
     private String description;
-//    @NotNull
-//    private List<MultipartFile> imageFiles;
     @NotNull
     private List<String> imageUrls;
     @NotNull

--- a/server/src/main/java/com/hexacore/tayo/car/dto/GetPresignedUrlsRequestDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/GetPresignedUrlsRequestDto.java
@@ -1,0 +1,15 @@
+package com.hexacore.tayo.car.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetPresignedUrlsRequestDto {
+    @NotNull
+    private final String fileName;
+    @NotNull
+    private final String fileType;
+    private final String prefix;
+}

--- a/server/src/main/java/com/hexacore/tayo/car/dto/GetPresignedUrlsResposneDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/GetPresignedUrlsResposneDto.java
@@ -1,0 +1,11 @@
+package com.hexacore.tayo.car.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetPresignedUrlsResposneDto {
+    private final String originalPresignedUrl;
+    private final String downscaledPresignedURl;
+}

--- a/server/src/main/java/com/hexacore/tayo/car/dto/UpdateCarRequestDto.java
+++ b/server/src/main/java/com/hexacore/tayo/car/dto/UpdateCarRequestDto.java
@@ -23,7 +23,7 @@ public class UpdateCarRequestDto {
     @NotNull
     private String description;
 
-    private List<MultipartFile> imageFiles;
+    private List<String> imageUrls;
 
     private List<Integer> imageIndexes;
 

--- a/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
+++ b/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
@@ -1,12 +1,17 @@
 package com.hexacore.tayo.util;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
+import java.net.URL;
 import java.sql.Timestamp;
+import java.time.Duration;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -20,6 +25,7 @@ import java.util.Arrays;
 public class S3Manager {
 
     private final AmazonS3 amazonS3Client;
+    private final String DOWNSCALED_PREFIX = "downscaled_";
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -53,5 +59,17 @@ public class S3Manager {
         String key = String.join("/", Arrays.copyOfRange(urlParts, 3, urlParts.length));
 
         amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, key));
+    }
+
+    public URL generatePresignedUrl(String fileName, String contentType, HttpMethod method) {
+        Date expiration = new Date(System.currentTimeMillis() + Duration.ofMinutes(5).toMillis());
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName)
+                        .withMethod(method)
+                        .withExpiration(expiration)
+                        .withContentType(contentType);
+
+        return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
     }
 }

--- a/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
+++ b/server/src/main/java/com/hexacore/tayo/util/S3Manager.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 public class S3Manager {
 
     private final AmazonS3 amazonS3Client;
-    private final String DOWNSCALED_PREFIX = "downscaled_";
+    private final Integer PRESIGNED_URL_EXPIRATION_MINUTE = 3;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -62,7 +62,7 @@ public class S3Manager {
     }
 
     public URL generatePresignedUrl(String fileName, String contentType, HttpMethod method) {
-        Date expiration = new Date(System.currentTimeMillis() + Duration.ofMinutes(5).toMillis());
+        Date expiration = new Date(System.currentTimeMillis() + Duration.ofMinutes(PRESIGNED_URL_EXPIRATION_MINUTE).toMillis());
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucket, fileName)

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceCreateCarTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceCreateCarTest.java
@@ -28,7 +28,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 public class CarServiceCreateCarTest {
@@ -54,11 +53,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "모델명 서브모델명", 10.0, "휘발유", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image2", "filename2.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image3", "filename3.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image4", "filename4.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image5", "filename5.png", "image/png", "dummy".getBytes())),
+                List.of("https://1", "https://2", "https://3", "https://4", "https://5"),
                 List.of(1, 2, 3, 4, 5));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());
@@ -66,7 +61,6 @@ public class CarServiceCreateCarTest {
                 .willReturn(Optional.of(Subcategory.builder().name("서브모델명").build()));
         given(mockCarRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(0L, createCarRequestDto.getCarNumber()))
                 .willReturn(Optional.empty());
-        given(mockS3Manager.uploadImage(Mockito.any())).willReturn("url");
 
         // when
         carService.createCar(createCarRequestDto, 0L);
@@ -83,11 +77,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "모델명 서브모델명", 10.0, "휘발유", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image2", "filename2.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image3", "filename3.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image4", "filename4.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image5", "filename5.png", "image/png", "dummy".getBytes())),
+                List.of("https://1", "https://2", "https://3", "https://4", "https://5"),
                 List.of(1, 2, 3, 4, 5));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());
@@ -97,7 +87,6 @@ public class CarServiceCreateCarTest {
                 .willReturn(Optional.of(Subcategory.builder().name("모델명").build()));
         given(mockCarRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(0L, createCarRequestDto.getCarNumber()))
                 .willReturn(Optional.of(new Car())); //
-        given(mockS3Manager.uploadImage(Mockito.any())).willReturn("url");
 
         // when
         carService.createCar(createCarRequestDto, 0L);
@@ -113,11 +102,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "모델명 서브모델명", 10.0, "휘발유", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image2", "filename2.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image3", "filename3.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image4", "filename4.png", "image/png", "dummy".getBytes()),
-                        new MockMultipartFile("image5", "filename5.png", "image/png", "dummy".getBytes())),
+                List.of("https://1", "https://2", "https://3", "https://4", "https://5"),
                 List.of(1, 2, 3, 4, 5));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());
@@ -128,7 +113,6 @@ public class CarServiceCreateCarTest {
         given(mockCategoryRepository.findAll()).willReturn(List.of(Category.builder().name("ETC").build()));
         given(mockCarRepository.findByOwner_IdAndCarNumberAndIsDeletedTrue(0L, createCarRequestDto.getCarNumber()))
                 .willReturn(Optional.empty()); //
-        given(mockS3Manager.uploadImage(Mockito.any())).willReturn("url");
 
         // when
         carService.createCar(createCarRequestDto, 0L);
@@ -145,7 +129,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "모델명 서브모델명", 10.0, "휘발유", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of("https://1"),
                 List.of(1));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.of(new Car()));
@@ -164,7 +148,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "서브모델명", 10.0, "휘발유", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of("https://1"),
                 List.of(1));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());
@@ -184,7 +168,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "서브모델명", 10.0, "휘발유", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of("https://1"),
                 List.of(1, 2, 3));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());
@@ -204,7 +188,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "서브모델명", 10.0, "휘발유", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.png", "image/png", "dummy image".getBytes())),
+                List.of("https://1"),
                 List.of(1));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());
@@ -228,11 +212,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "서브모델명", 10.0, "가솔린", "경차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image2", "filename2.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image3", "filename3.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image4", "filename4.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image5", "filename5.txt", "text/plain", "dummy".getBytes())),
+                List.of("https://1", "https://2", "https://3", "https://4", "https://5"),
                 List.of(1, 2, 3, 4, 5));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());
@@ -253,11 +233,7 @@ public class CarServiceCreateCarTest {
         CreateCarRequestDto createCarRequestDto = new CreateCarRequestDto("11주 1111", "서브모델명", 10.0, "휘발유", "중중형차", 2,
                 2020, 10000, "경기도 테스트 주소",
                 new Position(10.0, 10.0), "설명",
-                List.of(new MockMultipartFile("image1", "filename1.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image2", "filename2.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image3", "filename3.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image4", "filename4.txt", "text/plain", "dummy".getBytes()),
-                        new MockMultipartFile("image5", "filename5.txt", "text/plain", "dummy".getBytes())),
+                List.of("https://1", "https://2", "https://3", "https://4", "https://5"),
                 List.of(1, 2, 3, 4, 5));
 
         given(mockCarRepository.findByOwner_IdAndIsDeletedFalse(0L)).willReturn(Optional.empty());

--- a/server/src/test/java/com/hexacore/tayo/car/CarServiceDeleteCarTest.java
+++ b/server/src/test/java/com/hexacore/tayo/car/CarServiceDeleteCarTest.java
@@ -6,6 +6,7 @@ import com.hexacore.tayo.car.model.CarImage;
 import com.hexacore.tayo.common.errors.ErrorCode;
 import com.hexacore.tayo.common.errors.GeneralException;
 
+import com.hexacore.tayo.lock.RangeLockManager;
 import com.hexacore.tayo.user.model.User;
 import com.hexacore.tayo.util.S3Manager;
 import java.util.List;
@@ -32,6 +33,8 @@ public class CarServiceDeleteCarTest {
     private CarDateRangeRepository carDateRangeRepository;
     @Mock
     private S3Manager s3Manager;
+    @Mock
+    private RangeLockManager lockManager;
     @InjectMocks
     private CarService carService;
 
@@ -44,6 +47,7 @@ public class CarServiceDeleteCarTest {
         BDDMockito.given(carRepository.findByIdAndIsDeletedFalse(carId)).willReturn(Optional.of(Car.builder().owner(User.builder().id(userId).build()).build()));
         BDDMockito.given(carImageRepository.findByCar_Id(Mockito.any()))
                 .willReturn(List.of(new CarImage(), new CarImage()));
+        BDDMockito.given(lockManager.acquireFullRangeLock(Mockito.anyString())).willReturn(true);
 
         // when
         carService.deleteCar(carId, userId);
@@ -61,6 +65,7 @@ public class CarServiceDeleteCarTest {
         Long carId = 0L;
         Long userId = 0L;
         BDDMockito.given(carRepository.findByIdAndIsDeletedFalse(carId)).willReturn(Optional.empty());
+        BDDMockito.given(lockManager.acquireFullRangeLock(Mockito.anyString())).willReturn(true);
 
         // when & then
         Assertions.assertThatThrownBy(() -> carService.deleteCar(carId, userId))
@@ -75,6 +80,7 @@ public class CarServiceDeleteCarTest {
         Long carId = 0L;
         Long userId = 0L;
         BDDMockito.given(carRepository.findByIdAndIsDeletedFalse(carId)).willReturn(Optional.of(Car.builder().owner(User.builder().id(1L).build()).build()));
+        BDDMockito.given(lockManager.acquireFullRangeLock(Mockito.anyString())).willReturn(true);
 
         // when & then
         Assertions.assertThatThrownBy(() -> carService.deleteCar(carId, userId))


### PR DESCRIPTION
close(#259)

## DONE

- [x] GET `/cars/presigned-urls` API 추가
- [x] 차량 등록, 차량 수정 API RequestDto 수정: imageFiles -> imageUrls
- [x] `CarService.saveImages` 수정: S3에 직접 이미지 업로드하는 로직 삭제 (@jomulagy 혹시 기존 로직과 비교해서 놓친 부분이 없는지 냉철한 코드리뷰 부탁드립니다)
- [x] 테스트 코드 수정

## 리뷰 포인트

### GET `/cars/presigned-urls`
Request Parameter
* `fileName`: string (ex. "image.png")
* `fileType`: string (ex. "image/png")
* `prefix?`: string (ex. "downscaled_")
```
/cars/presigned-urls?fileName={fileName}&fileType={fileType}&prefix={prefix}
```

Response
* prefix가 전달된 경우 downscaledPresignedUrl도 함께 제공, prefix가 전달되지 않은 경우에는 downscaledPresignedUrl = null
```json
{
    "success": true,
    "code": 200,
    "message": "OK",
    "data": {
        "originalPresignedUrl": "https://hexacore-bucket.s3.ap-northeast-2.amazonaws.com/hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240224T161849Z&X-Amz-SignedHeaders=content-type%3Bhost&X-Amz-Expires=299&X-Amz-Credential=AKIARJRPQGMHXHKHPN4W%2F20240224%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=1e0b8e96c8e7f56e57dfcd33f325a0edcbc9194df452a212943828117d3c8cca",
        "downscaledPresignedURl": "https://hexacore-bucket.s3.ap-northeast-2.amazonaws.com/downscaled_hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240224T161849Z&X-Amz-SignedHeaders=content-type%3Bhost&X-Amz-Expires=299&X-Amz-Credential=AKIARJRPQGMHXHKHPN4W%2F20240224%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=e317980b696ba9ab891287283ccb74f929393d534e31c6b736045955db6d554e"
    }
}
```
### Presigned-Url
* 현재 Presigned-url 생성 요청 시 유효 시간을 3분으로 설정했습니다.
* 회원가입 및 회원 정보 수정 로직에서 `S3Manger.uploadImage` 메서드를 사용하고 있어 삭제하지 않았습니다. 추후 시간이된다면 수정하도록 하겠습니다!

