### PR TITLE
[FE] #277: 검색 화면에서 필터링 적용이 되지 않는 이슈

### DIFF
--- a/client/src/pages/home/components/sidebar/SideBar.tsx
+++ b/client/src/pages/home/components/sidebar/SideBar.tsx
@@ -48,26 +48,26 @@ function SideBar({ models }: SideBarProps) {
       showToast('검색 실패', '최고 가격은 최저 가격보다 높아야합니다.');
       return;
     }
-    
+
     const activeKeys = Array.from(activeCarTypes.entries())
       .filter(([, value]) => value === true)
       .map(([key]) => key);
 
     const queryString = new URLSearchParams(location.search);
     if (activeKeys.length !== 0) {
-      queryString.append('type', activeKeys.toString());
+      queryString.set('type', activeKeys.toString());
     }
     if (selectedCategory) {
-      queryString.append('category', selectedCategory.id.toString());
+      queryString.set('category', selectedCategory.id.toString());
     }
     if (selectedSubcategory.length !== 0) {
-      queryString.append('subcategory', selectedSubcategory.map((c) => c.id).toString());
+      queryString.set('subcategory', selectedSubcategory.map((c) => c.id).toString());
     }
     if (minPriceNumber) {
-      queryString.append('minPrice', minPriceNumber.toString());
+      queryString.set('minPrice', minPriceNumber.toString());
     }
     if (maxPriceNumber) {
-      queryString.append('maxPrice', maxPriceNumber.toString());
+      queryString.set('maxPrice', maxPriceNumber.toString());
     }
     navigate(`?${queryString}`);
   };


### PR DESCRIPTION
close(#277)

## DONE

- [x] 사이드 바에서 필토링 조건을 여러번 적용하지 못하는 에러 해결

## 리뷰 포인트

기존에는 "필터 적용하기" 버튼을 클릭하면 `queryString.append()` 방식으로 조건을 추가하여, 중복된 필터링 조건을 다시 적용하는 경우 중복된 key-value가 추가되어 조건이 적용되지 않는 이슈가 있었습니다. 따라서 `queryString.set()` 메서드를 사용하여 중복된 key를 추가하려는 경우에는 업데이트가 되도록 수정했습니다.
